### PR TITLE
Fix handling of multiple cookies

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -9,7 +9,19 @@ function fastifyCookieSetCookie (name, value, options) {
     opts.expires = new Date(opts.expires)
   }
   const serialized = cookie.serialize(name, value, opts)
-  this.header('Set-Cookie', serialized)
+
+  let setCookie = this.res.getHeader('Set-Cookie')
+  if (!setCookie) {
+    this.header('Set-Cookie', serialized)
+    return this
+  }
+
+  if (typeof setCookie === 'string') {
+    setCookie = [setCookie]
+  }
+
+  setCookie.push(serialized)
+  this.header('Set-Cookie', setCookie)
   return this
 }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -43,6 +43,44 @@ test('cookies get set correctly', (t) => {
   })
 })
 
+test('should set multiple cookies', (t) => {
+  t.plan(8)
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.listen(0, (err) => {
+    if (err) tap.error(err)
+    fastify.server.unref()
+
+    const reqOpts = {
+      method: 'GET',
+      baseUrl: 'http://localhost:' + fastify.server.address().port
+    }
+    const req = request.defaults(reqOpts)
+
+    fastify.get('/', (req, reply) => {
+      reply
+        .setCookie('foo', 'foo')
+        .setCookie('bar', 'test')
+        .send({hello: 'world'})
+    })
+
+    const jar = request.jar()
+    req({uri: '/', jar}, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.deepEqual(JSON.parse(body), {hello: 'world'})
+
+      const cookies = jar.getCookies(reqOpts.baseUrl + '/')
+      t.is(cookies.length, 2)
+      t.is(cookies[0].key, 'foo')
+      t.is(cookies[0].value, 'foo')
+      t.is(cookies[1].key, 'bar')
+      t.is(cookies[1].value, 'test')
+    })
+  })
+})
+
 test('cookies get set correctly with millisecond dates', (t) => {
   t.plan(8)
   const fastify = Fastify()


### PR DESCRIPTION
It is currently not possible to set multiple cookies with `fastify-cookie`. Each call of `setCookie(name, value, options)` overrides the `Set-Cookie` header set by the previous call.

In the following example only the second cookie is set:
```js
fastify.get('/', (req, reply) => {
    reply
    .setCookie('foo', 'foo')
    .setCookie('bar', 'test')
    .send({hello: 'world'})
})
```

This PR fixes this problem.