### PR TITLE
Fix multiple cookies to be arrayified, not Header folded

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -10,7 +10,7 @@ function fastifyCookieSetCookie (name, value, options) {
   }
   const serialized = cookie.serialize(name, value, opts)
 
-  let setCookie = this.res.getHeader('Set-Cookie')
+  let setCookie = this.getHeader('Set-Cookie')
   if (!setCookie) {
     this.header('Set-Cookie', serialized)
     return this
@@ -21,6 +21,7 @@ function fastifyCookieSetCookie (name, value, options) {
   }
 
   setCookie.push(serialized)
+  this.removeHeader('Set-Cookie')
   this.header('Set-Cookie', setCookie)
   return this
 }

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -44,7 +44,7 @@ test('cookies get set correctly', (t) => {
 })
 
 test('should set multiple cookies', (t) => {
-  t.plan(8)
+  t.plan(10)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -52,6 +52,7 @@ test('should set multiple cookies', (t) => {
     reply
       .setCookie('foo', 'foo')
       .setCookie('bar', 'test')
+      .setCookie('wee', 'woo')
       .send({hello: 'world'})
   })
 
@@ -72,11 +73,13 @@ test('should set multiple cookies', (t) => {
       t.deepEqual(JSON.parse(body), {hello: 'world'})
 
       const cookies = jar.getCookies(reqOpts.baseUrl + '/')
-      t.is(cookies.length, 2)
+      t.is(cookies.length, 3)
       t.is(cookies[0].key, 'foo')
       t.is(cookies[0].value, 'foo')
       t.is(cookies[1].key, 'bar')
       t.is(cookies[1].value, 'test')
+      t.is(cookies[2].key, 'wee')
+      t.is(cookies[2].value, 'woo')
     })
   })
 })


### PR DESCRIPTION
We had an issue where multiple cookies, specifically 3 above would be using default `header` folding, which delimits Set-Cookie with commas which is not to Set-Cookie spec of 1 cookie per header.
After adding a 3rd cookie to the test, the issue was happening.

The issue was in the following code

```js
  let setCookie = this.res.getHeader('Set-Cookie') //always returns null
  if (!setCookie) {
    //Always hits this code path
    this.header('Set-Cookie', serialized)
    return this
  }
```

Found out that the `this.getHeader` is stateful and `this.res.getHeader` is not, so I updated that

```js
  //Now returns cookie after first header is set
  let setCookie = this.getHeader('Set-Cookie')
```
I added `this.removeHeader('Set-Cookie')` as now the headers were additive rather than replacing the arrayified cookie

```js
  setCookie.push(serialized)
  this.removeHeader('Set-Cookie')
  this.header('Set-Cookie', setCookie)
```