### PR TITLE
move `@types/cookie` from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
-    "@types/cookie": "^0.3.1",
     "fastify": "^1.13.0",
     "pre-commit": "^1.2.2",
     "request": "^2.83.0",
@@ -40,6 +39,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
+    "@types/cookie": "^0.3.1",
     "cookie": "^0.3.1",
     "fastify-plugin": "^1.2.1"
   }


### PR DESCRIPTION
For now, people who installed `fastify-cookie` and use Typescript would see a compiler error: 

```
error TS7016: Could not find a declaration file for module 'cookie'.
Try `npm install @types/cookie` if it exists or add a new declaration (.d.ts) file containing `declare module 'cookie';`
```

Move `@types/cookie` from devDependencies to dependencies can fix this error.