### PR TITLE
Extend plugin types to accept HTTP2 request/response/server types

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,12 +1,9 @@
 /// <reference types="node" />
 import * as fastify from 'fastify';
-import {IncomingMessage, ServerResponse, Server} from 'http';
-import {Http2ServerRequest, Http2ServerResponse, Http2Server} from 'http2';
 import {FastifyRequest, DefaultQuery, Plugin} from 'fastify';
+import {IncomingMessage, ServerResponse} from 'http';
+import {Http2ServerRequest, Http2ServerResponse} from 'http2';
 
-interface FastifyCookieOptions {}
-
-type HttpServer  = Server | Http2Server;
 type HttpRequest = IncomingMessage | Http2ServerRequest;
 type HttpResponse = ServerResponse | Http2ServerResponse;
 
@@ -35,7 +32,7 @@ declare module 'fastify' {
     secure?: boolean;
   }
 
-  interface FastifyReply<HttpResponse = HttpResponse> {
+  interface FastifyReply<HttpResponse> {
     /**
      * Set response cookie
      * @param name Cookie name
@@ -50,5 +47,10 @@ declare module 'fastify' {
   }
 }
 
-declare const plugin: Plugin<HttpServer, HttpRequest, HttpResponse, FastifyCookieOptions>;
-export = plugin;
+declare function fastifyCookie(): void;
+
+declare namespace fastifyCookie {
+  interface FastifyCookieOptions {}
+}
+
+export = fastifyCookie;

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,13 +1,18 @@
 /// <reference types="node" />
 import * as fastify from 'fastify';
 import {IncomingMessage, ServerResponse, Server} from 'http';
+import {Http2ServerRequest, Http2ServerResponse, Http2Server} from 'http2';
 import {FastifyRequest, DefaultQuery, Plugin} from 'fastify';
 
 interface FastifyCookieOptions {}
 
+type HttpServer  = Server | Http2Server;
+type HttpRequest = IncomingMessage | Http2ServerRequest;
+type HttpResponse = ServerResponse | Http2ServerResponse;
+
 declare module 'fastify' {
   interface FastifyRequest<
-    HttpRequest = IncomingMessage,
+    HttpRequest = HttpRequest,
     Query = fastify.DefaultQuery,
     Params = fastify.DefaultParams,
     Headers = fastify.DefaultHeaders,
@@ -30,7 +35,7 @@ declare module 'fastify' {
     secure?: boolean;
   }
 
-  interface FastifyReply<HttpResponse = ServerResponse> {
+  interface FastifyReply<HttpResponse = HttpResponse> {
     /**
      * Set response cookie
      * @param name Cookie name
@@ -45,5 +50,5 @@ declare module 'fastify' {
   }
 }
 
-declare const plugin: Plugin<Server, IncomingMessage, ServerResponse, FastifyCookieOptions>;
+declare const plugin: Plugin<HttpServer, HttpRequest, HttpResponse, FastifyCookieOptions>;
 export = plugin;

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,12 +1,29 @@
 import fastify = require('fastify');
+import http2 = require('http2');
 import cookie = require('../');
 
-const app = fastify();
+const appWithImplicitHttp = fastify();
 
-app
+appWithImplicitHttp
   .register(cookie)
   .after(() => {
-    app.get('/', (request, reply) => {
+    appWithImplicitHttp.get('/', (request, reply) => {
+      const test = request.cookies.test;
+      reply.setCookie('test', test, { domain: 'example.com', path: '/' }).send({hello: 'world'});
+    })
+  });
+
+const appWithHttp2: fastify.FastifyInstance<
+  http2.Http2Server,
+  http2.Http2ServerRequest,
+  http2.Http2ServerResponse
+> = fastify();
+
+
+appWithHttp2
+  .register(cookie)
+  .after(() => {
+    appWithHttp2.get('/', (request, reply) => {
       const test = request.cookies.test;
       reply.setCookie('test', test, { domain: 'example.com', path: '/' }).send({hello: 'world'});
     })


### PR DESCRIPTION
Addresses #17 

Replaces areas in which the HTTP request, response, and server types are taken and extends them to accept HTTP2 types.