### PR TITLE
Use onRequest instead of preHandler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,8 +5,8 @@
 A plugin for [Fastify](http://fastify.io/) that adds support for reading and
 setting cookies.
 
-This plugin's cookie parsing works via Fastify's `preHandler` hook. Therefore,
-you should register it prior to any other `preHandler` hooks that will depend
+This plugin's cookie parsing works via Fastify's `onRequest` hook. Therefore,
+you should register it prior to any other `onRequest` hooks that will depend
 upon this plugin's actions.
 
 ## Example
@@ -33,7 +33,7 @@ fastify.get('/', (req, reply) => {
 
 ### Parsing
 
-Cookies are parsed in the `preHandler` Fastify hook and attached to the request
+Cookies are parsed in the `onRequest` Fastify hook and attached to the request
 as an object named `cookies`. Thus, if a request contains the header
 `Cookie: foo=foo` then, within your handler, `req.cookies.foo` would equal
 `'foo'`.

--- a/plugin.js
+++ b/plugin.js
@@ -26,7 +26,7 @@ function fastifyCookieSetCookie (name, value, options) {
   return this
 }
 
-function fastifyCookiePreHandler (fastifyReq, fastifyRes, done) {
+function fastifyCookieOnReqHandler (fastifyReq, fastifyRes, done) {
   const cookieHeader = fastifyReq.req.headers.cookie
   fastifyReq.cookies = (cookieHeader) ? cookie.parse(cookieHeader) : {}
   done()
@@ -35,7 +35,7 @@ function fastifyCookiePreHandler (fastifyReq, fastifyRes, done) {
 function plugin (fastify, options, next) {
   fastify.decorateRequest('cookies', {})
   fastify.decorateReply('setCookie', fastifyCookieSetCookie)
-  fastify.addHook('preHandler', fastifyCookiePreHandler)
+  fastify.addHook('onRequest', fastifyCookieOnReqHandler)
   next()
 }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -123,9 +123,19 @@ test('cookies get set correctly with millisecond dates', (t) => {
 })
 
 test('parses incoming cookies', (t) => {
-  t.plan(6)
+  t.plan(6 + 3 * 3)
   const fastify = Fastify()
   fastify.register(plugin)
+
+  // check that it parses the cookies in the onRequest hook
+  for (let hook of ['preParsing', 'preValidation', 'preHandler']) {
+    fastify.addHook(hook, (req, reply, done) => {
+      t.ok(req.cookies)
+      t.ok(req.cookies.bar)
+      t.is(req.cookies.bar, 'bar')
+      done()
+    })
+  }
 
   fastify.get('/test2', (req, reply) => {
     t.ok(req.cookies)


### PR DESCRIPTION
Now that Fastify v2 exists, we can hook in at the correct part of the lifecycle. This PR does that.