### PR TITLE
Update minimum version passed to fastify-plugin

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -40,6 +40,6 @@ function plugin (fastify, options, next) {
 }
 
 module.exports = fp(plugin, {
-  fastify: '>=1.1.0',
+  fastify: '>=2.0.0',
   name: 'fastify-cookie'
 })


### PR DESCRIPTION
With fastify-cookie v3.0, Fastify v2.0 is required, so the minimum version needs to be updated.