### PR TITLE
Pass option to cookie parse

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,8 @@ supports both Fastify@1 and Fastify@2.
 const fastify = require('fastify')()
 
 fastify.register(require('fastify-cookie'), {
-  secret: "my-secret" // for cookies signature
+  secret: "my-secret", // for cookies signature
+  parseOptions: {}     // options for parsing cookies
 })
 
 fastify.get('/', (req, reply) => {
@@ -46,6 +47,8 @@ Cookies are parsed in the `onRequest` Fastify hook and attached to the request
 as an object named `cookies`. Thus, if a request contains the header
 `Cookie: foo=foo` then, within your handler, `req.cookies.foo` would equal
 `'foo'`.
+
+You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cookieparsestr-options) by setting an object named `parseOptions` in the plugin config object.
 
 ### Sending
 

--- a/plugin.js
+++ b/plugin.js
@@ -39,7 +39,9 @@ function fastifyCookieClearCookie (reply, name, options) {
 function onReqHandlerWrapper (options) {
   return function fastifyCookieOnReqHandler (fastifyReq, fastifyRes, done) {
     const cookieHeader = fastifyReq.req.headers.cookie
-    fastifyReq.cookies = (cookieHeader) ? cookie.parse(cookieHeader, options) : {}
+    if (cookieHeader) {
+      fastifyReq.cookies = cookie.parse(cookieHeader, options)
+    }
     done()
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -36,10 +36,12 @@ function fastifyCookieClearCookie (reply, name, options) {
   return fastifyCookieSetCookie(reply, name, '', opts)
 }
 
-function fastifyCookieOnReqHandler (fastifyReq, fastifyRes, done) {
-  const cookieHeader = fastifyReq.req.headers.cookie
-  fastifyReq.cookies = (cookieHeader) ? cookie.parse(cookieHeader) : {}
-  done()
+function onReqHandlerWrapper (options) {
+  return function fastifyCookieOnReqHandler (fastifyReq, fastifyRes, done) {
+    const cookieHeader = fastifyReq.req.headers.cookie
+    fastifyReq.cookies = (cookieHeader) ? cookie.parse(cookieHeader, options) : {}
+    done()
+  }
 }
 
 function plugin (fastify, options, next) {
@@ -55,7 +57,7 @@ function plugin (fastify, options, next) {
   fastify.decorateReply('unsignCookie', function unsignCookieWrapper (value) {
     return cookieSignature.unsign(value, secret)
   })
-  fastify.addHook('onRequest', fastifyCookieOnReqHandler)
+  fastify.addHook('onRequest', onReqHandlerWrapper(options.parseOptions))
   next()
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

https://github.com/fastify/fastify-cookie/issues/48
Add `parseOption` (better name is welcomed) option to allow passing options to `cookie.parse()`.
And replace an unneeded conditional operator with an `if` statement.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
