### PR TITLE
Add 'none' option to CookieSerializeOptions.sameSite

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -28,7 +28,7 @@ declare module 'fastify' {
     httpOnly?: boolean;
     maxAge?: number;
     path?: string;
-    sameSite?: boolean | 'lax' | 'strict';
+    sameSite?: boolean | 'lax' | 'strict' | 'none';
     secure?: boolean;
     signed?: boolean;
   }

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -34,3 +34,41 @@ appWithHttp2
       .send({hello: 'world'});
     })
   });
+
+
+const testSamesiteOptionsApp = fastify();
+
+testSamesiteOptionsApp
+.register(cookie)
+.after(() => {
+  appWithImplicitHttp.get('/test-samesite-option-true', (request, reply) => {
+    const test = request.cookies.test;
+    reply
+    .setCookie('test', test, { sameSite: true })
+    .send({hello: 'world'});
+  })
+  appWithImplicitHttp.get('/test-samesite-option-false', (request, reply) => {
+    const test = request.cookies.test;
+    reply
+    .setCookie('test', test, { sameSite: false })
+    .send({hello: 'world'});
+  })
+  appWithImplicitHttp.get('/test-samesite-option-lax', (request, reply) => {
+    const test = request.cookies.test;
+    reply
+    .setCookie('test', test, { sameSite: 'lax' })
+    .send({hello: 'world'});
+  })
+  appWithImplicitHttp.get('/test-samesite-option-strict', (request, reply) => {
+    const test = request.cookies.test;
+    reply
+    .setCookie('test', test, { sameSite: 'strict' })
+    .send({hello: 'world'});
+  })
+  appWithImplicitHttp.get('/test-samesite-option-none', (request, reply) => {
+    const test = request.cookies.test;
+    reply
+    .setCookie('test', test, { sameSite: 'none' })
+    .send({hello: 'world'});
+  })
+});


### PR DESCRIPTION
https://github.com/fastify/fastify-cookie/issues/61: Add "none" option for the CookieSerializeOptions.sameSite parameter as specified in https://www.npmjs.com/package/cookie#options-1