### PR TITLE
Updated to rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
     "@types/node": "^13.1.0",
-    "fastify": "^3.0.0-rc.1",
+    "fastify": "^3.0.0-rc.4",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",
     "standard": "^14.0.2",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -3,14 +3,14 @@
 import { FastifyPlugin } from 'fastify';
 
 declare module 'fastify' {
-  interface FastifyRequestInterface {
+  interface FastifyRequest {
     /**
      * Request cookies
      */
     cookies: { [cookieName: string]: string };
   }
 
-  interface FastifyReplyInterface {
+  interface FastifyReply {
     /**
      * Set response cookie
      * @param name Cookie name
@@ -21,7 +21,7 @@ declare module 'fastify' {
       name: string,
       value: string,
       options?: CookieSerializeOptions
-    ): FastifyReplyInterface;
+    ): FastifyReply;
 
     /**
      * clear response cookie
@@ -31,7 +31,7 @@ declare module 'fastify' {
     clearCookie(
       name: string,
       options?: CookieSerializeOptions
-    ): FastifyReplyInterface;
+    ): FastifyReply;
 
     /**
      * Unsigns the specified cookie using the secret provided.

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -100,7 +100,7 @@ test('parses incoming cookies', (t) => {
   fastify.register(plugin)
 
   // check that it parses the cookies in the onRequest hook
-  for (const hook of ['preParsing', 'preValidation', 'preHandler']) {
+  for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
       t.ok(req.cookies)
       t.ok(req.cookies.bar)
@@ -108,6 +108,13 @@ test('parses incoming cookies', (t) => {
       done()
     })
   }
+
+  fastify.addHook('preParsing', (req, reply, payload, done) => {
+    t.ok(req.cookies)
+    t.ok(req.cookies.bar)
+    t.is(req.cookies.bar, 'bar')
+    done()
+  })
 
   fastify.get('/test2', (req, reply) => {
     t.ok(req.cookies)


### PR DESCRIPTION
As titled, unfortunately rc.4 shipped a few incompatibilities on the types.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
