### PR TITLE
feat: add decorator to manually parse cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ on the cookie path `/`.
 + `options`: an options object as described in the [cookie serialize][cs]
 documentation. Its optional to pass `options` object
 
-### Manual cookie parse
+### Manual cookie parsing
 
 The method `parseCookie(cookieHeader)` is added to the `fastify` instance
 via the Fastify `decorate` API. Thus, `fastify.parseCookie('sessionId=aYb4uTIhdBXC')`

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ on the cookie path `/`.
 + `options`: an options object as described in the [cookie serialize][cs]
 documentation. Its optional to pass `options` object
 
+### Manual cookie parse
+
+The method `parseCookie(cookieHeader)` is added to the `fastify` instance
+via the Fastify `decorate` API. Thus, `fastify.parseCookie('sessionId=aYb4uTIhdBXC')`
+will parse the raw cookie header and return an object `{ "sessionId": "aYb4uTIhdBXC" }`.
+
 [cs]: https://www.npmjs.com/package/cookie#options-1
 
 ## License

--- a/plugin.js
+++ b/plugin.js
@@ -36,12 +36,16 @@ function fastifyCookieClearCookie (reply, name, options) {
   return fastifyCookieSetCookie(reply, name, '', opts)
 }
 
+function fastifyParseCookie (cookieHeader, options) {
+  return cookie.parse(cookieHeader, options)
+}
+
 function onReqHandlerWrapper (options) {
   return function fastifyCookieOnReqHandler (fastifyReq, fastifyRes, done) {
     fastifyReq.cookies = {} // New container per request. Issue #53
     const cookieHeader = fastifyReq.raw.headers.cookie
     if (cookieHeader) {
-      fastifyReq.cookies = cookie.parse(cookieHeader, options)
+      fastifyReq.cookies = fastifyParseCookie(cookieHeader, options)
     }
     done()
   }
@@ -50,6 +54,9 @@ function onReqHandlerWrapper (options) {
 function plugin (fastify, options, next) {
   const secret = options ? options.secret || '' : ''
 
+  fastify.decorate('parseCookie', function parseCookie (cookieHeader) {
+    return fastifyParseCookie(cookieHeader, options)
+  })
   fastify.decorateRequest('cookies', {})
   fastify.decorateReply('setCookie', function setCookieWrapper (name, value, options) {
     return fastifyCookieSetCookie(this, name, value, options, secret)

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -278,3 +278,15 @@ test('issue 53', (t) => {
     t.is(response.body, 'done')
   })
 })
+
+test('parse cookie manually using decorator', (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.ready(() => {
+    t.ok(fastify.parseCookie)
+    t.deepEqual(fastify.parseCookie('foo=bar', {}), { foo: 'bar' })
+    t.end()
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Hi there,

I added this decorator to help me decrypt cookies/sessions when using `fastify-websocket` (see https://github.com/fastify/fastify-websocket/issues/70) , since wsHandlers don't have access to the `FastifyRequest ` you have to manually decrypt cookies/sessions. I've already submitted a PR to `fastify-session` to be able to decrypt sessions manually here https://github.com/SerayaEryn/fastify-session/pull/128.

However I would like to parse the cookie manually without pulling in the `cookie` package and duplicating `options` logic in two locations, hence this added decorator to make this step a little easier