### PR TITLE
feat: Allow passing a custom signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ fastify.get('/', (req, reply) => {
 })
 ```
 
+## Options
+
+- `secret`: A `String` to use as secret to sign the cookie using [`cookie-signature`](http://npm.im/cookie-signature). If you want to implement more sophisticated cookie signing mechanism, you can supply an `Object` instead. Read more about it in [Custom cookie signer](#custom-cookie-signer).
+
+- `parseOptions`: An `Object` to pass as options to [cookie parse](https://github.com/jshttp/cookie#cookieparsestr-options).
+
 ## API
 
 ### Parsing
@@ -81,6 +87,27 @@ via the Fastify `decorate` API. Thus, `fastify.parseCookie('sessionId=aYb4uTIhdB
 will parse the raw cookie header and return an object `{ "sessionId": "aYb4uTIhdBXC" }`.
 
 [cs]: https://www.npmjs.com/package/cookie#options-1
+
+<a name="custom-cookie-signer"></a>
+### Custom cookie signer
+
+The `secret` option optionally accepts an object with `sign` and `unsign` functions. Useful if you want to implement custom cookie signing mechanism with rotating signing key for example.
+
+**Example:**
+```js
+fastify.register(require('fastify-cookie'), {
+  secret: {
+    sign: (value) => {
+      // sign using custom logic
+      return signedValue
+    },
+    unsign: (value) => {
+      // unsign using custom logic
+      return unsignedValue
+    }
+  }
+})
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^14.14.8",
     "fastify": "^3.0.0",
     "pre-commit": "^1.2.2",
+    "sinon": "^9.2.1",
     "snazzy": "^9.0.0",
     "standard": "^16.0.3",
     "tap": "^14.11.0",

--- a/signer.js
+++ b/signer.js
@@ -1,0 +1,13 @@
+const cookieSignature = require('cookie-signature')
+
+module.exports = function (secret) {
+  const sign = (value) => {
+    return cookieSignature.sign(value, secret)
+  }
+
+  const unsign = (value) => {
+    return cookieSignature.unsign(value, secret)
+  }
+
+  return { sign, unsign }
+}

--- a/signer.js
+++ b/signer.js
@@ -1,13 +1,10 @@
+'use strict'
+
 const cookieSignature = require('cookie-signature')
 
 module.exports = function (secret) {
-  const sign = (value) => {
-    return cookieSignature.sign(value, secret)
+  return {
+    sign: value => cookieSignature.sign(value, secret),
+    unsign: value => cookieSignature.unsign(value, secret)
   }
-
-  const unsign = (value) => {
-    return cookieSignature.unsign(value, secret)
-  }
-
-  return { sign, unsign }
 }

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -3,6 +3,7 @@
 const tap = require('tap')
 const test = tap.test
 const Fastify = require('fastify')
+const sinon = require('sinon')
 const cookieSignature = require('cookie-signature')
 const plugin = require('../')
 
@@ -191,7 +192,7 @@ test('cookies gets cleared correctly', (t) => {
 })
 
 test('cookies signature', (t) => {
-  t.plan(2)
+  t.plan(4)
 
   t.test('unsign', t => {
     t.plan(6)
@@ -220,6 +221,36 @@ test('cookies signature', (t) => {
     })
   })
 
+  t.test('custom signer', t => {
+    t.plan(7)
+    const fastify = Fastify()
+    const signStub = sinon.stub().returns('SIGNED-VALUE')
+    const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
+    const secret = { sign: signStub, unsign: unsignStub }
+    fastify.register(plugin, { secret })
+
+    fastify.get('/test1', (req, reply) => {
+      reply
+        .setCookie('foo', 'bar', { signed: true })
+        .send({ hello: 'world' })
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/test1'
+    }, (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 200)
+      t.deepEqual(JSON.parse(res.body), { hello: 'world' })
+
+      const cookies = res.cookies
+      t.is(cookies.length, 1)
+      t.is(cookies[0].name, 'foo')
+      t.is(cookies[0].value, 'SIGNED-VALUE')
+      t.ok(signStub.calledOnceWithExactly('bar'))
+    })
+  })
+
   t.test('unsignCookie decorator', t => {
     t.plan(3)
     const fastify = Fastify()
@@ -242,6 +273,34 @@ test('cookies signature', (t) => {
       t.error(err)
       t.strictEqual(res.statusCode, 200)
       t.deepEqual(JSON.parse(res.body), { unsigned: 'foo' })
+    })
+  })
+
+  t.test('unsignCookie decorator with custom signer', t => {
+    t.plan(4)
+    const fastify = Fastify()
+    const signStub = sinon.stub().returns('SIGNED-VALUE')
+    const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
+    const secret = { sign: signStub, unsign: unsignStub }
+    fastify.register(plugin, { secret })
+
+    fastify.get('/test1', (req, reply) => {
+      reply.send({
+        unsigned: reply.unsignCookie(req.cookies.foo, secret)
+      })
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/test1',
+      headers: {
+        cookie: 'foo=SOME-SIGNED-VALUE'
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 200)
+      t.deepEqual(JSON.parse(res.body), { unsigned: 'ORIGINAL VALUE' })
+      t.ok(unsignStub.calledOnceWithExactly('SOME-SIGNED-VALUE'))
     })
   })
 })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const tap = require('tap')
+const test = tap.test
+const cookieSignature = require('cookie-signature')
+const signerFactory = require('../signer')
+
+const secret = 'my-secret'
+const signer = signerFactory(secret)
+
+test('signer.sign', (t) => {
+  t.plan(1)
+
+  const input = 'some-value'
+  const result = signer.sign(input)
+
+  t.is(result, cookieSignature.sign(input, secret))
+})
+
+test('signer.unsign', (t) => {
+  t.plan(1)
+
+  const input = cookieSignature.sign('some-value', secret)
+  const result = signer.unsign(input)
+
+  t.is(result, 'some-value')
+})


### PR DESCRIPTION
Adds a custom signer support. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
