### PR TITLE
fix: unsignCookie return type (#93)

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -39,7 +39,11 @@ declare module 'fastify' {
      */
     unsignCookie(
       value: string,
-    ): string | false;
+    ): {
+      valid: boolean;
+      renew: boolean;
+      value: string | false;
+    };
   }
 }
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -42,7 +42,7 @@ declare module 'fastify' {
     ): {
       valid: boolean;
       renew: boolean;
-      value: string | false;
+      value: string | null;
     };
   }
 }
@@ -60,7 +60,7 @@ export interface CookieSerializeOptions {
 }
 
 export interface FastifyCookieOptions {
-  secret?: string;
+  secret?: string | string[];
 }
 
 declare const fastifyCookie: FastifyPlugin<FastifyCookieOptions>;

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify';
 import cookie from '../plugin';
+import { expectType } from 'tsd'
 
 const server = fastify();
 
@@ -80,3 +81,23 @@ appWithImplicitHttpSigned.after(() => {
       .send({ hello: 'world' });
   })
 });
+
+const appWithRotationSecret = fastify()
+
+appWithRotationSecret
+  .register(cookie, {
+    secret: ['testsecret']
+  })
+appWithRotationSecret.after(() => {
+  server.get('/', (request, reply) => {
+    reply.unsignCookie(request.cookies.test)
+    const { valid, renew, value } = reply.unsignCookie('test')
+
+    expectType<boolean>(valid)
+    expectType<boolean>(renew)
+    expectType<string | null>(value)
+
+    reply
+      .send({ hello: 'world' });
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Resolve: #93 
Test cannot be added because there are no dependencies of ```fastify```, so the type cannot be tested

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
