### PR TITLE
Make TS types more consistent with other fastify plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
-    "@types/node": "^14.14.8",
+    "@types/node": "^14.14.14",
     "fastify": "^3.0.0",
     "pre-commit": "^1.2.2",
     "sinon": "^9.2.1",
@@ -44,7 +44,7 @@
     "standard": "^16.0.3",
     "tap": "^14.11.0",
     "tsd": "^0.14.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.3"
   },
   "dependencies": {
     "cookie": "^0.4.0",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { FastifyPlugin } from 'fastify';
+import { FastifyPluginCallback } from 'fastify';
 
 declare module 'fastify' {
   interface FastifyRequest {
@@ -63,6 +63,7 @@ export interface FastifyCookieOptions {
   secret?: string | string[];
 }
 
-declare const fastifyCookie: FastifyPlugin<FastifyCookieOptions>;
+declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
 
 export default fastifyCookie;
+export { fastifyCookie }

--- a/plugin.js
+++ b/plugin.js
@@ -75,7 +75,21 @@ function plugin (fastify, options, next) {
   next()
 }
 
-module.exports = fp(plugin, {
+const fastifyCookie = fp(plugin, {
   fastify: '>=3',
   name: 'fastify-cookie'
 })
+
+/**
+ * These export configurations enable JS and TS developers
+ * to consume fastify-cookie in whatever way best suits their needs.
+ * Some examples of supported import syntax includes:
+ * - `const fastifyCookie = require('fastify-cookie')`
+ * - `const { fastifyCookie } = require('fastify-cookie')`
+ * - `import * as fastifyCookie from 'fastify-cookie'`
+ * - `import { fastifyCookie } from 'fastify-cookie'`
+ * - `import fastifyCookie from 'fastify-cookie'`
+ */
+fastifyCookie.fastifyCookie = fastifyCookie
+fastifyCookie.default = fastifyCookie
+module.exports = fastifyCookie

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,6 +1,34 @@
-import fastify from 'fastify';
-import cookie from '../plugin';
+import fastify, {FastifyInstance, FastifyPluginCallback} from 'fastify';
+import cookie, {FastifyCookieOptions} from '../plugin';
 import { expectType } from 'tsd'
+
+import { fastifyCookie as fastifyCookieNamed } from "../";
+import fastifyCookieDefault from "../";
+import * as fastifyCookieStar from "../";
+import fastifyCookieCjsImport = require("../");
+import {Server} from "http";
+const fastifyCookieCjs = require("../");
+
+const app: FastifyInstance = fastify();
+app.register(fastifyCookieNamed);
+app.register(fastifyCookieDefault);
+app.register(fastifyCookieCjs);
+app.register(fastifyCookieCjsImport.default);
+app.register(fastifyCookieCjsImport.fastifyCookie);
+app.register(fastifyCookieStar.default);
+app.register(fastifyCookieStar.fastifyCookie);
+
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieNamed);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieDefault);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.default);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
+  fastifyCookieCjsImport.fastifyCookie
+);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieStar.default);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
+  fastifyCookieStar.fastifyCookie
+);
+expectType<any>(fastifyCookieCjs);
 
 const server = fastify();
 


### PR DESCRIPTION
Introduces the "infamous triplet" for module exports.
Replaces deprecated FastifyPlugin type.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
