### PR TITLE
Decorate fastify instance with an `unsignCookie` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ fastify.register(require('fastify-cookie'), {
 ### Manual cookie unsigning 
 
 The method `unsignCookie(value)` is added to the `fastify` instance and the `reply` object 
-via the Fastify `decorate` & `decorateReply` APIs. using it on a signed cookie will call the
-the provided signer's (or the default signer if no custom implementation is provided) unsign method on the cookie.
+via the Fastify `decorate` & `decorateReply` APIs. Using it on a signed cookie will call the
+the provided signer's (or the default signer if no custom implementation is provided) `unsign` method on the cookie.
 
 **Example:**
 
@@ -172,7 +172,7 @@ the provided signer's (or the default signer if no custom implementation is prov
 fastify.register(require('fastify-cookie'), { secret: 'my-secret' })
 
 fastify.get('/', (req, rep) => {
-  if (!fastify.unsign(req.cookie.foo).valid) {
+  if (fastify.unsign(req.cookie.foo).valid === false) {
     rep.send('cookie is invalid')
     return
   }

--- a/README.md
+++ b/README.md
@@ -160,6 +160,28 @@ fastify.register(require('fastify-cookie'), {
 })
 ```
 
+### Manual cookie unsigning 
+
+The method `unsignCookie(value)` is added to the `fastify` instance and the `reply` object 
+via the Fastify `decorate` & `decorateReply` APIs. using it on a signed cookie will call the
+the provided signer's (or the default signer if no custom implementation is provided) unsign method on the cookie.
+
+**Example:**
+
+```js
+fastify.register(require('fastify-cookie'), { secret: 'my-secret' })
+
+fastify.get('/', (req, rep) => {
+  if (!fastify.unsign(req.cookie.foo).valid) {
+    rep.send('cookie is invalid')
+    return
+  }
+
+  rep.send('cookie is valid')
+})
+```
+
+
 ## License
 
 [MIT License](http://jsumners.mit-license.org/)

--- a/plugin.js
+++ b/plugin.js
@@ -60,6 +60,11 @@ function plugin (fastify, options, next) {
   fastify.decorate('parseCookie', function parseCookie (cookieHeader) {
     return cookie.parse(cookieHeader, options.parseOptions)
   })
+
+  fastify.decorate('unsignCookie', function unsignCookie (val) {
+    return signer.unsign(val)
+  })
+
   fastify.decorateRequest('cookies', null)
   fastify.decorateRequest('unsignCookie', function unsignCookieRequestWrapper (value) {
     return signer.unsign(value)

--- a/plugin.js
+++ b/plugin.js
@@ -61,8 +61,8 @@ function plugin (fastify, options, next) {
     return cookie.parse(cookieHeader, options.parseOptions)
   })
 
-  fastify.decorate('unsignCookie', function unsignCookie (val) {
-    return signer.unsign(val)
+  fastify.decorate('unsignCookie', function unsignCookie (value) {
+    return signer.unsign(value)
   })
 
   fastify.decorateRequest('cookies', null)

--- a/plugin.js
+++ b/plugin.js
@@ -58,14 +58,14 @@ function plugin (fastify, options, next) {
   const signer = typeof secret === 'string' || enableRotation ? signerFactory(secret) : secret
 
   fastify.decorate('parseCookie', parseCookie)
-  fastify.decorate('unsignCookie', unsginCookie)
+  fastify.decorate('unsignCookie', unsignCookie)
 
   fastify.decorateRequest('cookies', null)
-  fastify.decorateRequest('unsignCookie', unsginCookie)
+  fastify.decorateRequest('unsignCookie', unsignCookie)
 
   fastify.decorateReply('setCookie', setCookie)
   fastify.decorateReply('clearCookie', clearCookie)
-  fastify.decorateReply('unsignCookie', unsginCookie)
+  fastify.decorateReply('unsignCookie', unsignCookie)
 
   fastify.addHook('onRequest', onReqHandlerWrapper(fastify))
 
@@ -76,7 +76,7 @@ function plugin (fastify, options, next) {
     return cookie.parse(cookieHeader, options.parseOptions)
   }
 
-  function unsginCookie (value) {
+  function unsignCookie (value) {
     return signer.unsign(value)
   }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -271,7 +271,7 @@ test('cookies gets cleared correctly', (t) => {
 })
 
 test('cookies signature', (t) => {
-  t.plan(8)
+  t.plan(9)
 
   t.test('unsign', t => {
     t.plan(6)
@@ -325,6 +325,32 @@ test('cookies signature', (t) => {
       t.is(cookies.length, 1)
       t.is(cookies[0].name, 'foo')
       t.is(cookieSignature.unsign(cookies[0].value, secret1), 'cookieVal') // decode using first key
+    })
+  })
+
+  t.test('unsginCookie via fastify instance', t => {
+    t.plan(3)
+    const fastify = Fastify()
+    const secret = 'bar'
+
+    fastify.register(plugin, { secret })
+
+    fastify.get('/test1', (req, rep) => {
+      rep.send({
+        unsigned: fastify.unsignCookie(req.cookies.foo)
+      })
+    })
+
+    fastify.inject({
+      method: 'GET',
+      url: '/test1',
+      headers: {
+        cookie: `foo=${cookieSignature.sign('foo', secret)}`
+      }
+    }, (err, res) => {
+      t.error(err)
+      t.strictEqual(res.statusCode, 200)
+      t.deepEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #99 by decorating the fastify instance with an `unsignCookie` method

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
