### PR TITLE
duplicate setCookie for express plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cook
 
 ### Sending
 
-The method `setCookie(name, value, options)` and its alias `cookie(name, value, options)` are added to the `reply` object
+The method `setCookie(name, value, options)`, and its alias `cookie(name, value, options)`, are added to the `reply` object
 via the Fastify `decorateReply` API. Thus, in a request handler,
 `reply.setCookie('foo', 'foo', {path: '/'})` or `reply.cookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
 with a value of `'foo'` on the cookie path `/`.

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ fastify.register(require('fastify-cookie'), {
 fastify.get('/', (req, reply) => {
   const aCookieValue = req.cookies.cookieName
   // `reply.unsingCookie()` is also available
-  const bCookie = req.unsignCookie(req.cookies.cookieSigned); 
+  const bCookie = req.unsignCookie(req.cookies.cookieSigned);
   reply
     .setCookie('foo', 'foo', {
       domain: 'example.com',
       path: '/'
     })
+    .cookie('baz', 'baz') // alias for setCookie
     .setCookie('bar', 'bar', {
       path: '/',
       signed: true
@@ -62,9 +63,9 @@ You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cook
 
 ### Sending
 
-The method `setCookie(name, value, options)` is added to the `reply` object
+The method `setCookie(name, value, options)` and its alias `cookie(name, value, options)` are added to the `reply` object
 via the Fastify `decorateReply` API. Thus, in a request handler,
-`reply.setCookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
+`reply.setCookie('foo', 'foo', {path: '/'})` or `reply.cookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
 with a value of `'foo'` on the cookie path `/`.
 
 + `name`: a string name for the cookie to be set
@@ -79,7 +80,7 @@ Following are _some_ of the precautions that should be taken to ensure the integ
 - It's important to use `options.httpOnly` cookies to prevent attacks like XSS.
 - Use signed cookies (`options.signed`) to ensure they are not getting tampered with on client-side by an attacker.
 - Use `__Host-` [Cookie Prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Attributes) to avoid Cookie Tossing attacks.
-- it's important to [use HTTPS for your website/app](https://letsencrypt.org/) to avoid a bunch of other potential security issues like [MITM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) etc. 
+- it's important to [use HTTPS for your website/app](https://letsencrypt.org/) to avoid a bunch of other potential security issues like [MITM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) etc.
 
 ### Clearing
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cook
 
 The method `setCookie(name, value, options)`, and its alias `cookie(name, value, options)`, are added to the `reply` object
 via the Fastify `decorateReply` API. Thus, in a request handler,
-`reply.setCookie('foo', 'foo', {path: '/'})` or `reply.cookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
+`reply.setCookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
 with a value of `'foo'` on the cookie path `/`.
 
 + `name`: a string name for the cookie to be set

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -22,19 +22,22 @@ declare module 'fastify' {
     };
   }
 
-  interface FastifyReply {
-    /**
-     * Set response cookie
-     * @param name Cookie name
-     * @param value Cookie value
-     * @param options Serialize options
-     */
-    setCookie(
-      name: string,
-      value: string,
-      options?: CookieSerializeOptions
-    ): FastifyReply;
+  /**
+   * Set response cookie
+   * @param name Cookie name
+   * @param value Cookie value
+   * @param options Serialize options
+   */
+  type setCookieWrapper = (
+    name: string,
+    value: string,
+    options?: CookieSerializeOptions
+  ) => FastifyReply
 
+  interface FastifyReply {
+    setCookie: setCookieWrapper;
+
+    cookie: setCookieWrapper
     /**
      * clear response cookie
      * @param name Cookie name

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -22,12 +22,6 @@ declare module 'fastify' {
     };
   }
 
-  /**
-   * Set response cookie
-   * @param name Cookie name
-   * @param value Cookie value
-   * @param options Serialize options
-   */
   type setCookieWrapper = (
     name: string,
     value: string,
@@ -35,8 +29,18 @@ declare module 'fastify' {
   ) => FastifyReply
 
   interface FastifyReply {
+  /**
+   * Set response cookie
+   * @name setCookie
+   * @param name Cookie name
+   * @param value Cookie value
+   * @param options Serialize options
+   */
     setCookie: setCookieWrapper;
 
+    /**
+     * @alias setCookie
+     */
     cookie: setCookieWrapper
     /**
      * clear response cookie

--- a/plugin.js
+++ b/plugin.js
@@ -67,6 +67,9 @@ function plugin (fastify, options, next) {
   fastify.decorateReply('setCookie', function setCookieWrapper (name, value, options) {
     return fastifyCookieSetCookie(this, name, value, options, signer)
   })
+  fastify.decorateReply('cookie', function setCookieWrapper (name, value, options) {
+    return fastifyCookieSetCookie(this, name, value, options, signer)
+  })
   fastify.decorateReply('clearCookie', function clearCookieWrapper (name, options) {
     return fastifyCookieClearCookie(this, name, options)
   })

--- a/plugin.js
+++ b/plugin.js
@@ -56,6 +56,9 @@ function plugin (fastify, options, next) {
   const secret = options.secret || ''
   const enableRotation = Array.isArray(secret)
   const signer = typeof secret === 'string' || enableRotation ? signerFactory(secret) : secret
+  function setCookieWrapper (name, value, options) {
+    return fastifyCookieSetCookie(this, name, value, options, signer)
+  }
 
   fastify.decorate('parseCookie', function parseCookie (cookieHeader) {
     return cookie.parse(cookieHeader, options.parseOptions)
@@ -64,12 +67,8 @@ function plugin (fastify, options, next) {
   fastify.decorateRequest('unsignCookie', function unsignCookieRequestWrapper (value) {
     return signer.unsign(value)
   })
-  fastify.decorateReply('setCookie', function setCookieWrapper (name, value, options) {
-    return fastifyCookieSetCookie(this, name, value, options, signer)
-  })
-  fastify.decorateReply('cookie', function setCookieWrapper (name, value, options) {
-    return fastifyCookieSetCookie(this, name, value, options, signer)
-  })
+  fastify.decorateReply('setCookie', setCookieWrapper)
+  fastify.decorateReply('cookie', setCookieWrapper)
   fastify.decorateReply('clearCookie', function clearCookieWrapper (name, options) {
     return fastifyCookieClearCookie(this, name, options)
   })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -34,6 +34,33 @@ test('cookies get set correctly', (t) => {
   })
 })
 
+test('express cookie compatibility', (t) => {
+  t.plan(7)
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.get('/espresso', (req, reply) => {
+    reply
+      .cookie('foo', 'foo', { path: '/' })
+      .send({ hello: 'world' })
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/espresso'
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.deepEqual(JSON.parse(res.body), { hello: 'world' })
+
+    const cookies = res.cookies
+    t.is(cookies.length, 1)
+    t.is(cookies[0].name, 'foo')
+    t.is(cookies[0].value, 'foo')
+    t.is(cookies[0].path, '/')
+  })
+})
+
 test('should set multiple cookies', (t) => {
   t.plan(10)
   const fastify = Fastify()
@@ -42,7 +69,7 @@ test('should set multiple cookies', (t) => {
   fastify.get('/', (req, reply) => {
     reply
       .setCookie('foo', 'foo')
-      .setCookie('bar', 'test')
+      .cookie('bar', 'test')
       .setCookie('wee', 'woo')
       .send({ hello: 'world' })
   })

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, {FastifyInstance, FastifyPluginCallback} from 'fastify';
+import fastify, {FastifyInstance, FastifyPluginCallback, FastifyReply} from 'fastify';
 import cookie, {FastifyCookieOptions} from '../plugin';
 import { expectType } from 'tsd'
 
@@ -37,6 +37,9 @@ server.register(cookie);
 server.after((_err) => {
   server.get('/', (request, reply) => {
     const test = request.cookies.test;
+
+    expectType<FastifyReply>(reply.cookie('bar', 'bar'))
+
     reply
       .setCookie('test', test, { domain: 'example.com', path: '/' })
       .clearCookie('foo')

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, {FastifyInstance, FastifyPluginCallback, FastifyReply} from 'fastify';
+import fastify, {FastifyInstance, FastifyPluginCallback, setCookieWrapper} from 'fastify';
 import cookie, {FastifyCookieOptions} from '../plugin';
 import { expectType } from 'tsd'
 
@@ -38,7 +38,8 @@ server.after((_err) => {
   server.get('/', (request, reply) => {
     const test = request.cookies.test;
 
-    expectType<FastifyReply>(reply.cookie('bar', 'bar'))
+    expectType<setCookieWrapper>(reply.cookie)
+    expectType<setCookieWrapper>(reply.setCookie)
 
     reply
       .setCookie('test', test, { domain: 'example.com', path: '/' })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

it makes express plugin compatible