### PR TITLE
Add missing unsignCookie function signature to the FastifyInstance interface

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -3,6 +3,20 @@
 import { FastifyPluginCallback } from 'fastify';
 
 declare module 'fastify' {
+  interface FastifyInstance {
+    /**
+     * Unsigns the specified cookie using the secret provided.
+     * @param value Cookie value
+     */
+    unsignCookie(
+      value: string,
+    ): {
+      valid: boolean;
+      renew: boolean;
+      value: string | null;
+    };
+  }
+
   interface FastifyRequest {
     /**
      * Request cookies

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -106,6 +106,9 @@ appWithImplicitHttpSigned
   })
 appWithImplicitHttpSigned.after(() => {
   server.get('/', (request, reply) => {
+    appWithImplicitHttpSigned.unsignCookie(request.cookies.test)
+    appWithImplicitHttpSigned.unsignCookie('test')
+
     reply.unsignCookie(request.cookies.test)
     reply.unsignCookie('test')
 


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-cookie/issues/121 (I'm not quite sure how to test it though, but it works in my codebase 😄 )

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~ (there is no more `benchmark` script)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
