### PR TITLE
fix: add parseCookie method types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,18 +35,18 @@
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
-    "@types/node": "^16.0.0",
-    "fastify": "^3.0.0",
+    "@types/node": "^16.11.6",
+    "fastify": "^3.23.0",
     "pre-commit": "^1.2.2",
-    "sinon": "^12.0.0",
+    "sinon": "^12.0.1",
     "snazzy": "^9.0.0",
-    "standard": "^16.0.3",
-    "tap": "^15.0.2",
+    "standard": "^16.0.4",
+    "tap": "^15.0.10",
     "tsd": "^0.18.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.4.4"
   },
   "dependencies": {
-    "cookie": "^0.4.0",
+    "cookie": "^0.4.1",
     "cookie-signature": "^1.1.0",
     "fastify-plugin": "^3.0.0"
   },

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -17,6 +17,7 @@ declare module 'fastify' {
     };
     /**
      * Manual cookie parsing method
+     * @docs https://github.com/fastify/fastify-cookie#manual-cookie-parsing
      * @param cookieHeader Raw cookie header value
      */
     parseCookie(

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -15,6 +15,15 @@ declare module 'fastify' {
       renew: boolean;
       value: string | null;
     };
+    /**
+     * Manual cookie parsing method
+     * @param cookieHeader Raw cookie header value
+     */
+    parseCookie(
+      cookieHeader: string
+    ): {
+      [key: string]: string;
+    }
   }
 
   interface FastifyRequest {

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -24,7 +24,7 @@ declare module 'fastify' {
       cookieHeader: string
     ): {
       [key: string]: string;
-    }
+    };
   }
 
   interface FastifyRequest {

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,13 +1,16 @@
-import fastify, {FastifyInstance, FastifyPluginCallback, setCookieWrapper} from 'fastify';
-import cookie, {FastifyCookieOptions} from '../plugin';
-import { expectType } from 'tsd'
+import fastify, {
+  FastifyInstance,
+  FastifyPluginCallback,
+  setCookieWrapper
+} from 'fastify';
+import { Server } from 'http';
+import { expectType } from 'tsd';
+import * as fastifyCookieStar from '../';
+import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed } from '../';
+import cookie, { FastifyCookieOptions } from '../plugin';
 
-import { fastifyCookie as fastifyCookieNamed } from "../";
-import fastifyCookieDefault from "../";
-import * as fastifyCookieStar from "../";
-import fastifyCookieCjsImport = require("../");
-import {Server} from "http";
-const fastifyCookieCjs = require("../");
+import fastifyCookieCjsImport = require('../');
+const fastifyCookieCjs = require('../');
 
 const app: FastifyInstance = fastify();
 app.register(fastifyCookieNamed);
@@ -35,6 +38,11 @@ const server = fastify();
 server.register(cookie);
 
 server.after((_err) => {
+  expectType<{ [key: string]: string }>(
+    // See https://github.com/fastify/fastify-cookie#manual-cookie-parsing
+    server.parseCookie('sessionId=aYb4uTIhdBXC')
+  );
+
   server.get('/', (request, reply) => {
     const test = request.cookies.test;
 


### PR DESCRIPTION
Hello,
- fix: add `parseCookie` method types
- chore: upgrade package dependencies
- refactor: add a JSDoc link to the documentation

Closes https://github.com/fastify/fastify-cookie/issues/145

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
