### PR TITLE
Add parseOptions object to FastifyCookieOptions

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -104,6 +104,7 @@ export interface CookieSerializeOptions {
 
 export interface FastifyCookieOptions {
   secret?: string | string[];
+  parseOptions?: CookieSerializeOptions;
 }
 
 declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;

--- a/plugin.js
+++ b/plugin.js
@@ -6,7 +6,7 @@ const cookie = require('./cookie')
 const signerFactory = require('./signer')
 
 function fastifyCookieSetCookie (reply, name, value, options, signer) {
-  const opts = Object.assign({}, options || {})
+  const opts = Object.assign({}, options)
   if (opts.expires && Number.isInteger(opts.expires)) {
     opts.expires = new Date(opts.expires)
   }
@@ -80,8 +80,10 @@ function plugin (fastify, options, next) {
     return signer.unsign(value)
   }
 
-  function setCookie (name, value, options) {
-    return fastifyCookieSetCookie(this, name, value, options, signer)
+  function setCookie (name, value, cookieOptions) {
+    const opts = Object.assign({}, options.parseOptions || {})
+    Object.assign(opts, cookieOptions)
+    return fastifyCookieSetCookie(this, name, value, opts, signer)
   }
 
   function clearCookie (name, options) {

--- a/plugin.js
+++ b/plugin.js
@@ -81,8 +81,7 @@ function plugin (fastify, options, next) {
   }
 
   function setCookie (name, value, cookieOptions) {
-    const opts = Object.assign({}, options.parseOptions || {})
-    Object.assign(opts, cookieOptions)
+    const opts = Object.assign({}, options.parseOptions, cookieOptions)
     return fastifyCookieSetCookie(this, name, value, opts, signer)
   }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -660,3 +660,37 @@ test('parse cookie manually using decorator', (t) => {
     t.end()
   })
 })
+
+test('cookies set with plugin options parseOptions field', (t) => {
+  t.plan(8)
+  const fastify = Fastify()
+  fastify.register(plugin, {
+    parseOptions: {
+      path: '/test',
+      domain: 'example.com'
+    }
+  })
+
+  fastify.get('/test', (req, reply) => {
+    reply.setCookie('foo', 'foo').send({ hello: 'world' })
+  })
+
+  fastify.inject(
+    {
+      method: 'GET',
+      url: '/test'
+    },
+    (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      t.same(JSON.parse(res.body), { hello: 'world' })
+
+      const cookies = res.cookies
+      t.equal(cookies.length, 1)
+      t.equal(cookies[0].name, 'foo')
+      t.equal(cookies[0].value, 'foo')
+      t.equal(cookies[0].path, '/test')
+      t.equal(cookies[0].domain, 'example.com')
+    }
+  )
+})

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -147,3 +147,31 @@ appWithRotationSecret.after(() => {
       .send({ hello: 'world' });
   })
 })
+const appWithParserOptions = fastify();
+
+const parseOptions: fastifyCookieStar.CookieSerializeOptions = {
+  domain: "example.com",
+  encode: (value: string) => value,
+  expires: new Date(),
+  httpOnly: true,
+  maxAge: 3600,
+  path: "/",
+  sameSite: "lax",
+  secure: true,
+  signed: true,
+};
+expectType<fastifyCookieStar.CookieSerializeOptions>(parseOptions);
+
+appWithParserOptions.register(cookie, {
+  secret: "testsecret",
+  parseOptions,
+});
+appWithParserOptions.after(() => {
+  server.get("/", (request, reply) => {
+    const { valid, renew, value } = reply.unsignCookie(request.cookies.test);
+
+    expectType<boolean>(valid);
+    expectType<boolean>(renew);
+    expectType<string | null>(value);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Add `parseOptions` type definitions to `FastifyCookieOptions` interface and utilize options in `setCookie` function.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
