### PR TITLE
test: add back `preParsing` hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
-    "@types/node": "^17.0.0",
-    "fastify": "^3.23.0",
+    "@types/node": "^17.0.8",
+    "fastify": "^3.25.3",
     "pre-commit": "^1.2.2",
     "sinon": "^12.0.1",
     "snazzy": "^9.0.0",
     "standard": "^16.0.4",
-    "tap": "^15.0.10",
-    "tsd": "^0.19.0",
-    "typescript": "^4.4.4"
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1",
+    "typescript": "^4.5.4"
   },
   "dependencies": {
     "cookie-signature": "^1.1.0",

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -202,7 +202,7 @@ test('expires should not be overridden in clearCookie', (t) => {
 })
 
 test('parses incoming cookies', (t) => {
-  t.plan(12)
+  t.plan(15)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -215,6 +215,13 @@ test('parses incoming cookies', (t) => {
       done()
     })
   }
+
+  fastify.addHook('preParsing', (req, reply, payload, done) => {
+    t.ok(req.cookies)
+    t.ok(req.cookies.bar)
+    t.equal(req.cookies.bar, 'bar')
+    done()
+  })
 
   fastify.get('/test2', (req, reply) => {
     t.ok(req.cookies)


### PR DESCRIPTION
Hello.

Following [this discussion](https://github.com/fastify/fastify/issues/3503), this PR aims to :
- add back `preParsing` hook tests
- upgrade package dependencies

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
