### PR TITLE
fix (types): return `this` instead of `FastifyReply`

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,3 @@
 100: true
+check-coverage: true
+coverage: true

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "scripts": {
     "lint": "standard | snazzy",
     "lint:ci": "standard",
-    "test": "tap test/*.test.js && npm run typescript",
-    "typescript": "tsd"
+    "lint:fix": "standard --fix",
+    "test": "npm run unit && npm run typescript",
+    "typescript": "tsd",
+    "unit": "tap -J \"test/*.test.js\"",
+    "unit:report": "npm run unit -- --coverage-report=html",
+    "unit:verbose": "npm run unit -- -Rspec"
   },
   "precommit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -35,19 +35,19 @@
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
-    "@types/node": "^17.0.8",
-    "fastify": "^3.25.3",
+    "@types/node": "^17.0.16",
+    "fastify": "^3.27.1",
     "pre-commit": "^1.2.2",
-    "sinon": "^13.0.0",
+    "sinon": "^13.0.1",
     "snazzy": "^9.0.0",
     "standard": "^16.0.4",
     "tap": "^15.1.6",
     "tsd": "^0.19.1",
-    "typescript": "^4.5.4"
+    "typescript": "^4.5.5"
   },
   "dependencies": {
     "cookie-signature": "^1.1.0",
-    "fastify-plugin": "^3.0.0"
+    "fastify-plugin": "^3.0.1"
   },
   "tsd": {
     "directory": "test"

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -60,12 +60,20 @@ declare module 'fastify' {
    * @param value Cookie value
    * @param options Serialize options
    */
-    setCookie: setCookieWrapper;
+    setCookie(
+      name: string,
+      value: string,
+      options?: CookieSerializeOptions
+    ): this;
 
     /**
      * @alias setCookie
      */
-    cookie: setCookieWrapper
+    cookie(
+      name: string,
+      value: string,
+      options?: CookieSerializeOptions
+    ): this;
     /**
      * clear response cookie
      * @param name Cookie name
@@ -74,7 +82,7 @@ declare module 'fastify' {
     clearCookie(
       name: string,
       options?: CookieSerializeOptions
-    ): FastifyReply;
+    ): this;
 
     /**
      * Unsigns the specified cookie using the secret provided.

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="node" />
+/// <reference types='node' />
 
 import { FastifyPluginCallback } from 'fastify';
 
@@ -8,9 +8,7 @@ declare module 'fastify' {
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(
-      value: string,
-    ): {
+    unsignCookie(value: string): {
       valid: boolean;
       renew: boolean;
       value: string | null;
@@ -20,9 +18,7 @@ declare module 'fastify' {
      * @docs https://github.com/fastify/fastify-cookie#manual-cookie-parsing
      * @param cookieHeader Raw cookie header value
      */
-    parseCookie(
-      cookieHeader: string
-    ): {
+    parseCookie(cookieHeader: string): {
       [key: string]: string;
     };
   }
@@ -37,29 +33,27 @@ declare module 'fastify' {
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(
-      value: string,
-    ): {
+    unsignCookie(value: string): {
       valid: boolean;
       renew: boolean;
       value: string | null;
     };
   }
 
-  type setCookieWrapper = (
+  export type setCookieWrapper = (
     name: string,
     value: string,
     options?: CookieSerializeOptions
-  ) => FastifyReply
+  ) => FastifyReply;
 
   interface FastifyReply {
-  /**
-   * Set response cookie
-   * @name setCookie
-   * @param name Cookie name
-   * @param value Cookie value
-   * @param options Serialize options
-   */
+    /**
+     * Set response cookie
+     * @name setCookie
+     * @param name Cookie name
+     * @param value Cookie value
+     * @param options Serialize options
+     */
     setCookie(
       name: string,
       value: string,
@@ -69,28 +63,19 @@ declare module 'fastify' {
     /**
      * @alias setCookie
      */
-    cookie(
-      name: string,
-      value: string,
-      options?: CookieSerializeOptions
-    ): this;
+    cookie(name: string, value: string, options?: CookieSerializeOptions): this;
     /**
      * clear response cookie
      * @param name Cookie name
      * @param options Serialize options
      */
-    clearCookie(
-      name: string,
-      options?: CookieSerializeOptions
-    ): this;
+    clearCookie(name: string, options?: CookieSerializeOptions): this;
 
     /**
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(
-      value: string,
-    ): {
+    unsignCookie(value: string): {
       valid: boolean;
       renew: boolean;
       value: string | null;
@@ -118,4 +103,4 @@ export interface FastifyCookieOptions {
 declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
 
 export default fastifyCookie;
-export { fastifyCookie }
+export { fastifyCookie };

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -64,6 +64,7 @@ declare module 'fastify' {
      * @alias setCookie
      */
     cookie(name: string, value: string, options?: CookieSerializeOptions): this;
+
     /**
      * clear response cookie
      * @param name Cookie name

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,16 +1,15 @@
-import fastify, {
-  FastifyInstance,
-  FastifyPluginCallback,
-  setCookieWrapper
-} from 'fastify';
+import fastify, { FastifyInstance, FastifyPluginCallback, FastifyReply, setCookieWrapper } from 'fastify';
 import { Server } from 'http';
 import { expectType } from 'tsd';
-import * as fastifyCookieStar from '../';
-import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed } from '../';
+import * as fastifyCookieStar from '..';
+import fastifyCookieDefault, {
+  CookieSerializeOptions,
+  fastifyCookie as fastifyCookieNamed
+} from '..';
 import cookie, { FastifyCookieOptions } from '../plugin';
 
-import fastifyCookieCjsImport = require('../');
-const fastifyCookieCjs = require('../');
+import fastifyCookieCjsImport = require('..');
+const fastifyCookieCjs = require('..');
 
 const app: FastifyInstance = fastify();
 app.register(fastifyCookieNamed);
@@ -24,9 +23,7 @@ app.register(fastifyCookieStar.fastifyCookie);
 expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieNamed);
 expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieDefault);
 expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.default);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
-  fastifyCookieCjsImport.fastifyCookie
-);
+expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.fastifyCookie);
 expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieStar.default);
 expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
   fastifyCookieStar.fastifyCookie
@@ -46,19 +43,19 @@ server.after((_err) => {
   server.get('/', (request, reply) => {
     const test = request.cookies.test;
 
-    expectType<setCookieWrapper>(reply.cookie)
-    expectType<setCookieWrapper>(reply.setCookie)
+    expectType<setCookieWrapper>(reply.cookie);
+    expectType<setCookieWrapper>(reply.setCookie);
 
     reply
       .setCookie('test', test, { domain: 'example.com', path: '/' })
       .clearCookie('foo')
       .send({ hello: 'world' });
-  })
+  });
 });
 
 const serverWithHttp2 = fastify({ http2: true });
 
-serverWithHttp2.register(cookie)
+serverWithHttp2.register(cookie);
 
 serverWithHttp2.after(() => {
   serverWithHttp2.get('/', (request, reply) => {
@@ -67,108 +64,98 @@ serverWithHttp2.after(() => {
       .setCookie('test', test, { domain: 'example.com', path: '/' })
       .clearCookie('foo')
       .send({ hello: 'world' });
-  })
+  });
 });
 
 const testSamesiteOptionsApp = fastify();
 
-testSamesiteOptionsApp.register(cookie)
+testSamesiteOptionsApp.register(cookie);
 testSamesiteOptionsApp.after(() => {
   server.get('/test-samesite-option-true', (request, reply) => {
     const test = request.cookies.test;
-    reply
-      .setCookie('test', test, { sameSite: true })
-      .send({ hello: 'world' });
-  })
+    reply.setCookie('test', test, { sameSite: true }).send({ hello: 'world' });
+  });
   server.get('/test-samesite-option-false', (request, reply) => {
     const test = request.cookies.test;
-    reply
-      .setCookie('test', test, { sameSite: false })
-      .send({ hello: 'world' });
-  })
+    reply.setCookie('test', test, { sameSite: false }).send({ hello: 'world' });
+  });
   server.get('/test-samesite-option-lax', (request, reply) => {
     const test = request.cookies.test;
-    reply
-      .setCookie('test', test, { sameSite: 'lax' })
-      .send({ hello: 'world' });
-  })
+    reply.setCookie('test', test, { sameSite: 'lax' }).send({ hello: 'world' });
+  });
   server.get('/test-samesite-option-strict', (request, reply) => {
     const test = request.cookies.test;
     reply
       .setCookie('test', test, { sameSite: 'strict' })
       .send({ hello: 'world' });
-  })
+  });
   server.get('/test-samesite-option-none', (request, reply) => {
     const test = request.cookies.test;
     reply
       .setCookie('test', test, { sameSite: 'none' })
       .send({ hello: 'world' });
-  })
+  });
 });
 
 const appWithImplicitHttpSigned = fastify();
 
-appWithImplicitHttpSigned
-  .register(cookie, {
-    secret: 'testsecret'
-  })
+appWithImplicitHttpSigned.register(cookie, {
+  secret: 'testsecret',
+});
 appWithImplicitHttpSigned.after(() => {
   server.get('/', (request, reply) => {
-    appWithImplicitHttpSigned.unsignCookie(request.cookies.test)
-    appWithImplicitHttpSigned.unsignCookie('test')
+    appWithImplicitHttpSigned.unsignCookie(request.cookies.test);
+    appWithImplicitHttpSigned.unsignCookie('test');
 
-    reply.unsignCookie(request.cookies.test)
-    reply.unsignCookie('test')
+    reply.unsignCookie(request.cookies.test);
+    reply.unsignCookie('test');
 
     request.unsignCookie(request.cookies.anotherTest);
     request.unsignCookie('anotherTest');
 
-    reply
-      .send({ hello: 'world' });
-  })
+    reply.send({ hello: 'world' });
+  });
 });
 
-const appWithRotationSecret = fastify()
+const appWithRotationSecret = fastify();
 
-appWithRotationSecret
-  .register(cookie, {
-    secret: ['testsecret']
-  })
+appWithRotationSecret.register(cookie, {
+  secret: ['testsecret'],
+});
 appWithRotationSecret.after(() => {
   server.get('/', (request, reply) => {
-    reply.unsignCookie(request.cookies.test)
-    const { valid, renew, value } = reply.unsignCookie('test')
+    reply.unsignCookie(request.cookies.test);
+    const { valid, renew, value } = reply.unsignCookie('test');
 
-    expectType<boolean>(valid)
-    expectType<boolean>(renew)
-    expectType<string | null>(value)
+    expectType<boolean>(valid);
+    expectType<boolean>(renew);
+    expectType<string | null>(value);
 
-    reply
-      .send({ hello: 'world' });
-  })
-})
+    reply.send({ hello: 'world' });
+  });
+});
 
 const appWithParseOptions = fastify();
 
 const parseOptions: fastifyCookieStar.CookieSerializeOptions = {
-  domain: "example.com",
+  domain: 'example.com',
   encode: (value: string) => value,
   expires: new Date(),
   httpOnly: true,
   maxAge: 3600,
-  path: "/",
-  sameSite: "lax",
+  path: '/',
+  sameSite: 'lax',
   secure: true,
   signed: true,
 };
 expectType<fastifyCookieStar.CookieSerializeOptions>(parseOptions);
 
 appWithParseOptions.register(cookie, {
-  secret: "testsecret",
+  secret: 'testsecret',
   parseOptions,
 });
 appWithParseOptions.after(() => {
-  server.get("/", (request, reply) => {
+  server.get('/', (request, reply) => {
     const { valid, renew, value } = reply.unsignCookie(request.cookies.test);
 
     expectType<boolean>(valid);

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -46,10 +46,12 @@ server.after((_err) => {
     expectType<setCookieWrapper>(reply.cookie);
     expectType<setCookieWrapper>(reply.setCookie);
 
-    reply
-      .setCookie('test', test, { domain: 'example.com', path: '/' })
-      .clearCookie('foo')
-      .send({ hello: 'world' });
+    expectType<FastifyReply>(
+      reply
+        .setCookie('test', test, { domain: 'example.com', path: '/' })
+        .clearCookie('foo')
+        .send({ hello: 'world' })
+    );
   });
 });
 


### PR DESCRIPTION
Hello.

This PR aims to :
- return `this` instead of `FastifyReply` to avoid reply typings re-initialization and allow reply decorators chaining (fix https://github.com/fastify/fastify-cookie/issues/166)
- update `.taprc` configuration file and add some npm scripts
- upgrade package dependencies

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
