### PR TITLE
Adjust secret type to allow custom signer

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -96,8 +96,17 @@ export interface CookieSerializeOptions {
   signed?: boolean;
 }
 
+interface Signer {
+  sign: (input: string) => string;
+  unsign: (input: string) => {
+    valid: boolean;
+    renew: boolean;
+    value: string | null;
+  };
+}
+
 export interface FastifyCookieOptions {
-  secret?: string | string[];
+  secret?: string | string[] | Signer;
   parseOptions?: CookieSerializeOptions;
 }
 


### PR DESCRIPTION
The current type definitions do not allow providing a custom signing object (as documented in the [README](https://github.com/fastify/fastify-cookie#custom-cookie-signer))