### PR TITLE
Improve typescript example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ fastify.get('/', (req, reply) => {
 ## TypeScript Example
 
 ```ts
-import { FastifyCookieOptions } from '@fastify/cookie'
+import type { FastifyCookieOptions } from '@fastify/cookie'
 import cookie from '@fastify/cookie'
 import fastify from 'fastify'
 


### PR DESCRIPTION
Changed the import to a type-only import, which is better practice in typescript.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
