### PR TITLE
Update Request Cookies Type to Add `undefined`

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -27,7 +27,7 @@ declare module 'fastify' {
     /**
      * Request cookies
      */
-    cookies: { [cookieName: string]: string };
+    cookies: { [cookieName: string]: string | undefined };
 
     /**
      * Unsigns the specified cookie using the secret provided.

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -42,13 +42,14 @@ server.after((_err) => {
 
   server.get('/', (request, reply) => {
     const test = request.cookies.test;
+    expectType<string | undefined>(test);
 
     expectType<setCookieWrapper>(reply.cookie);
     expectType<setCookieWrapper>(reply.setCookie);
 
     expectType<FastifyReply>(
       reply
-        .setCookie('test', test, { domain: 'example.com', path: '/' })
+        .setCookie('test', test!, { domain: 'example.com', path: '/' })
         .clearCookie('foo')
         .send({ hello: 'world' })
     );
@@ -63,7 +64,7 @@ serverWithHttp2.after(() => {
   serverWithHttp2.get('/', (request, reply) => {
     const test = request.cookies.test;
     reply
-      .setCookie('test', test, { domain: 'example.com', path: '/' })
+      .setCookie('test', test!, { domain: 'example.com', path: '/' })
       .clearCookie('foo')
       .send({ hello: 'world' });
   });
@@ -75,26 +76,26 @@ testSamesiteOptionsApp.register(cookie);
 testSamesiteOptionsApp.after(() => {
   server.get('/test-samesite-option-true', (request, reply) => {
     const test = request.cookies.test;
-    reply.setCookie('test', test, { sameSite: true }).send({ hello: 'world' });
+    reply.setCookie('test', test!, { sameSite: true }).send({ hello: 'world' });
   });
   server.get('/test-samesite-option-false', (request, reply) => {
     const test = request.cookies.test;
-    reply.setCookie('test', test, { sameSite: false }).send({ hello: 'world' });
+    reply.setCookie('test', test!, { sameSite: false }).send({ hello: 'world' });
   });
   server.get('/test-samesite-option-lax', (request, reply) => {
     const test = request.cookies.test;
-    reply.setCookie('test', test, { sameSite: 'lax' }).send({ hello: 'world' });
+    reply.setCookie('test', test!, { sameSite: 'lax' }).send({ hello: 'world' });
   });
   server.get('/test-samesite-option-strict', (request, reply) => {
     const test = request.cookies.test;
     reply
-      .setCookie('test', test, { sameSite: 'strict' })
+      .setCookie('test', test!, { sameSite: 'strict' })
       .send({ hello: 'world' });
   });
   server.get('/test-samesite-option-none', (request, reply) => {
     const test = request.cookies.test;
     reply
-      .setCookie('test', test, { sameSite: 'none' })
+      .setCookie('test', test!, { sameSite: 'none' })
       .send({ hello: 'world' });
   });
 });
@@ -106,13 +107,13 @@ appWithImplicitHttpSigned.register(cookie, {
 });
 appWithImplicitHttpSigned.after(() => {
   server.get('/', (request, reply) => {
-    appWithImplicitHttpSigned.unsignCookie(request.cookies.test);
+    appWithImplicitHttpSigned.unsignCookie(request.cookies.test!);
     appWithImplicitHttpSigned.unsignCookie('test');
 
-    reply.unsignCookie(request.cookies.test);
+    reply.unsignCookie(request.cookies.test!);
     reply.unsignCookie('test');
 
-    request.unsignCookie(request.cookies.anotherTest);
+    request.unsignCookie(request.cookies.anotherTest!);
     request.unsignCookie('anotherTest');
 
     reply.send({ hello: 'world' });
@@ -126,7 +127,7 @@ appWithRotationSecret.register(cookie, {
 });
 appWithRotationSecret.after(() => {
   server.get('/', (request, reply) => {
-    reply.unsignCookie(request.cookies.test);
+    reply.unsignCookie(request.cookies.test!);
     const { valid, renew, value } = reply.unsignCookie('test');
 
     expectType<boolean>(valid);
@@ -158,7 +159,7 @@ appWithParseOptions.register(cookie, {
 });
 appWithParseOptions.after(() => {
   server.get('/', (request, reply) => {
-    const { valid, renew, value } = reply.unsignCookie(request.cookies.test);
+    const { valid, renew, value } = reply.unsignCookie(request.cookies.test!);
 
     expectType<boolean>(valid);
     expectType<boolean>(renew);
@@ -179,7 +180,7 @@ appWithCustomSigner.register(cookie, {
 })
 appWithCustomSigner.after(() => {
   server.get('/', (request, reply) => {
-    reply.unsignCookie(request.cookies.test)
+    reply.unsignCookie(request.cookies.test!)
     const { valid, renew, value } = reply.unsignCookie('test')
 
     expectType<boolean>(valid)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Updates the TypeScript types to add `| undefined` to a request's cookies. 

This is a breaking change as previously cookies were typed to be a string, while now that cannot be assumed. (Possibly 7.1.0?)

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
