### PR TITLE
fix: plugin type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ test('Request requires signed cookie', async () => {
 with signerFactory
 
 ```js
-const { signerFactory } = require('@fastify/cookie');
+const { fastifyCookie } = require('@fastify/cookie');
 
-const signer = signerFactory('secret');
+const signer = fastifyCookie.signerFactory('secret');
 const signedValue = signer.sign('test');
 const {valid, renew, value } = signer.unsign(signedValue);
 ```
@@ -248,10 +248,10 @@ const {valid, renew, value } = signer.unsign(signedValue);
 with sign/unsign utilities
 
 ```js
-const { sign, unsign } = require('@fastify/cookie');
+const { fastifyCookie } = require('@fastify/cookie');
 
-const signedValue = sign('test', 'secret');
-const unsignedvalue = unsign(signedValue, 'secret');
+const signedValue = fastifyCookie.sign('test', 'secret');
+const unsignedvalue = fastifyCookie.unsign(signedValue, 'secret');
 ```
 
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -112,16 +112,18 @@ interface Signer {
   };
 }
 
-declare const signerFactory: Signer;
-declare const sign: (value: string, secret: string) => string;
-declare const unsign: (input: string, secret: string) => string | false;
-
 export interface FastifyCookieOptions {
   secret?: string | string[] | Signer;
   parseOptions?: CookieSerializeOptions;
 }
 
-declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
+export interface FastifyCookie extends FastifyPluginCallback<NonNullable<FastifyCookieOptions>>{
+  signerFactory:  (secret: string) => Signer;
+  sign: (value: string, secret: string) => string;
+  unsign: (input: string, secret: string) => string | false;
+}
+
+declare const fastifyCookie: FastifyCookie;
 
 export default fastifyCookie;
-export { fastifyCookie, signerFactory, sign, unsign };
+export { fastifyCookie };

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -128,7 +128,7 @@ export interface Unsign {
 export interface SignerFactory{(secret: string) : Signer}
 
 export interface FastifyCookie extends FastifyPluginCallback<NonNullable<FastifyCookieOptions>>{
-  signerFactory:  (secret: string) => Signer;
+  signerFactory: SignerFactory;
   sign: Sign;
   unsign: Unsign;
 }

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -103,7 +103,7 @@ export interface CookieSerializeOptions {
   signed?: boolean;
 }
 
-interface Signer {
+export interface Signer {
   sign: (input: string) => string;
   unsign: (input: string) => {
     valid: boolean;
@@ -117,10 +117,20 @@ export interface FastifyCookieOptions {
   parseOptions?: CookieSerializeOptions;
 }
 
+export interface Sign {
+  (value: string, secret: string): string;
+}
+
+export interface Unsign {
+  (input: string, secret: string): string | false;
+}
+
+export interface SignerFactory{(secret: string) : Signer}
+
 export interface FastifyCookie extends FastifyPluginCallback<NonNullable<FastifyCookieOptions>>{
   signerFactory:  (secret: string) => Signer;
-  sign: (value: string, secret: string) => string;
-  unsign: (input: string, secret: string) => string | false;
+  sign: Sign;
+  unsign: Unsign;
 }
 
 declare const fastifyCookie: FastifyCookie;

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -117,15 +117,9 @@ export interface FastifyCookieOptions {
   parseOptions?: CookieSerializeOptions;
 }
 
-export interface Sign {
-  (value: string, secret: string): string;
-}
-
-export interface Unsign {
-  (input: string, secret: string): string | false;
-}
-
-export interface SignerFactory{(secret: string) : Signer}
+export type Sign  = (value: string, secret: string) => string;
+export type Unsign  = (input: string, secret: string) => string | false;
+export type SignerFactory = (secret: string) => Signer;
 
 export interface FastifyCookie extends FastifyPluginCallback<NonNullable<FastifyCookieOptions>>{
   signerFactory: SignerFactory;

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -19,12 +19,12 @@ app.register(fastifyCookieCjsImport.fastifyCookie);
 app.register(fastifyCookieStar.default);
 app.register(fastifyCookieStar.fastifyCookie);
 
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieNamed);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieDefault);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.default);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.fastifyCookie);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieStar.default);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieNamed);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieDefault);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.default);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.fastifyCookie);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieStar.default);
+expectType<fastifyCookieStar.FastifyCookie>(
   fastifyCookieStar.fastifyCookie
 );
 expectType<any>(fastifyCookieCjs);

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,13 +1,10 @@
-import fastify, { FastifyInstance, FastifyPluginCallback, FastifyReply, setCookieWrapper } from 'fastify';
-import { Server } from 'http';
+import cookie from '../plugin';
 import { expectType } from 'tsd';
 import * as fastifyCookieStar from '..';
-import fastifyCookieDefault, {
-  fastifyCookie as fastifyCookieNamed
-} from '..';
-import cookie, { FastifyCookieOptions } from '../plugin';
-
 import fastifyCookieCjsImport = require('..');
+import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed  } from '..';
+import fastify, { FastifyInstance,  FastifyReply, setCookieWrapper } from 'fastify';
+
 const fastifyCookieCjs = require('..');
 
 const app: FastifyInstance = fastify();
@@ -28,6 +25,12 @@ expectType<fastifyCookieStar.FastifyCookie>(
   fastifyCookieStar.fastifyCookie
 );
 expectType<any>(fastifyCookieCjs);
+
+const { sign, unsign, signerFactory} = fastifyCookieNamed;
+
+expectType<fastifyCookieStar.Sign>(sign);
+expectType<fastifyCookieStar.Unsign>(unsign);
+expectType<fastifyCookieStar.SignerFactory >(signerFactory );
 
 const server = fastify();
 

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -26,11 +26,13 @@ expectType<fastifyCookieStar.FastifyCookie>(
 );
 expectType<any>(fastifyCookieCjs);
 
-const { sign, unsign, signerFactory } = fastifyCookieNamed;
+expectType<fastifyCookieStar.Sign>(fastifyCookieDefault.sign);
+expectType<fastifyCookieStar.Unsign>(fastifyCookieDefault.unsign);
+expectType<fastifyCookieStar.SignerFactory >(fastifyCookieDefault.signerFactory );
 
-expectType<fastifyCookieStar.Sign>(sign);
-expectType<fastifyCookieStar.Unsign>(unsign);
-expectType<fastifyCookieStar.SignerFactory >(signerFactory );
+expectType<fastifyCookieStar.Sign>(fastifyCookieNamed.sign);
+expectType<fastifyCookieStar.Unsign>(fastifyCookieNamed.unsign);
+expectType<fastifyCookieStar.SignerFactory >(fastifyCookieNamed.signerFactory );
 
 const server = fastify();
 

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -26,7 +26,7 @@ expectType<fastifyCookieStar.FastifyCookie>(
 );
 expectType<any>(fastifyCookieCjs);
 
-const { sign, unsign, signerFactory} = fastifyCookieNamed;
+const { sign, unsign, signerFactory } = fastifyCookieNamed;
 
 expectType<fastifyCookieStar.Sign>(sign);
 expectType<fastifyCookieStar.Unsign>(unsign);


### PR DESCRIPTION
Have fixed type definition for the last release

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
