### PR TITLE
integrate cookie-signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ with a value of `'foo'` on the cookie path `/`.
 + `name`: a string name for the cookie to be set
 + `value`: a string value for the cookie
 + `options`: an options object as described in the [cookie serialize][cs] documentation
-  with a extra param "signed" for signed cookie
++ `options.signed`: the cookie should be signed
++ `options.secure`: if set to `true` it will set the Secure-flag. If it is set to `"auto"` Secure-flag is set when the connection is using tls.
 
 #### Securing the cookie
 

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ test('Request requires signed cookie', async () => {
 
 ### Manual signing/unsigning with low level utilities
 
-with signerFactory
+with Signer
 
 ```js
-const { signerFactory } = require('@fastify/cookie');
+const { Signer } = require('@fastify/cookie');
 
-const signer = signerFactory('secret');
+const signer = new Signer('secret');
 const signedValue = signer.sign('test');
 const {valid, renew, value } = signer.unsign(signedValue);
 ```

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ const {valid, renew, value } = signer.unsign(signedValue);
 with sign/unsign utilities
 
 ```js
-const { sign, unsign } = require('@fastify/cookie');
+const { fastifyCookie } = require('@fastify/cookie');
 
-const signedValue = sign('test', 'secret');
-const unsignedvalue = unsign(signedValue, 'secret');
+const signedValue = fastifyCookie.sign('test', 'secret');
+const unsignedvalue = fastifyCookie.unsign(signedValue, 'secret');
 ```
 
 

--- a/benchmark/signer-multi.js
+++ b/benchmark/signer-multi.js
@@ -1,8 +1,8 @@
 const Benchmark = require('benchmark')
-const SignerFactory = require('../signer')
+const Signer = require('../signer')
 const suite = new Benchmark.Suite()
 
-const signer = SignerFactory(['abcd', 'asdf', 'vadfa'])
+const signer = Signer(['abcd', 'asdf', 'vadfa'])
 const signedValue = signer.sign('test', 'vadfa')
 
 suite

--- a/benchmark/signer-multi.js
+++ b/benchmark/signer-multi.js
@@ -1,0 +1,18 @@
+const Benchmark = require('benchmark')
+const SignerFactory = require('../signer')
+const suite = new Benchmark.Suite()
+
+const signer = SignerFactory(['abcd', 'asdf', 'vadfa'])
+const signedValue = signer.sign('test', 'vadfa')
+
+suite
+  .add('sign', function () {
+    signer.sign('test')
+  })
+  .add('unsign', function () {
+    signer.unsign(signedValue)
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .run({ delay: 0 })

--- a/benchmark/signer.js
+++ b/benchmark/signer.js
@@ -1,8 +1,8 @@
 const Benchmark = require('benchmark')
-const SignerFactory = require('../signer')
+const Signer = require('../signer')
 const suite = new Benchmark.Suite()
 
-const signer = SignerFactory('abcd')
+const signer = Signer('abcd')
 const signedValue = signer.sign('test')
 suite
   .add('sign', function () {

--- a/benchmark/signer.js
+++ b/benchmark/signer.js
@@ -1,0 +1,17 @@
+const Benchmark = require('benchmark')
+const SignerFactory = require('../signer')
+const suite = new Benchmark.Suite()
+
+const signer = SignerFactory('abcd')
+const signedValue = signer.sign('test')
+suite
+  .add('sign', function () {
+    signer.sign('test')
+  })
+  .add('unsign', function () {
+    signer.unsign(signedValue)
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .run({ delay: 0 })

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
   "devDependencies": {
     "@types/node": "^18.0.0",
+    "benchmark": "^2.1.4",
     "fastify": "^4.0.0-rc.2",
     "pre-commit": "^1.2.2",
     "sinon": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/cookie",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Plugin for fastify to add support for cookies",
   "main": "plugin.js",
   "types": "plugin.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/cookie",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Plugin for fastify to add support for cookies",
   "main": "plugin.js",
   "types": "plugin.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "cookie": "^0.5.0",
-    "cookie-signature": "^1.1.0",
     "fastify-plugin": "^3.0.1"
   },
   "tsd": {

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -117,7 +117,17 @@ export interface FastifyCookieOptions {
   parseOptions?: CookieSerializeOptions;
 }
 
-declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
+export type Sign  = (value: string, secret: string) => string;
+export type Unsign  = (input: string, secret: string) => string | false;
+export type SignerFactory = (secret: string) => Signer;
+
+export interface FastifyCookie extends FastifyPluginCallback<NonNullable<FastifyCookieOptions>>{
+  signerFactory: SignerFactory;
+  sign: Sign;
+  unsign: Unsign;
+}
+
+declare const fastifyCookie: FastifyCookie;
 
 export default fastifyCookie;
 export { fastifyCookie, Signer, sign, unsign };

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -102,7 +102,12 @@ interface Signer {
   unsign: (input: string) => UnsignResult;
 }
 
-declare function signerFactory(secret: string, algorithm?: string) : Signer;
+declare class SignerFactory {
+  constructor (secrets: string | Array<string>, algorithm?: string)
+  sign: (value: string) => string;
+  unsign: (input: string) => UnsignResult;
+}
+
 declare const sign: (value: string, secret: string, algorithm?: string) => string;
 declare const unsign: (input: string, secret: string, algorithm?: string) => UnsignResult;
 
@@ -115,4 +120,4 @@ export interface FastifyCookieOptions {
 declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
 
 export default fastifyCookie;
-export { fastifyCookie, signerFactory, sign, unsign };
+export { fastifyCookie, SignerFactory, sign, unsign };

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -8,11 +8,7 @@ declare module 'fastify' {
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(value: string): {
-      valid: boolean;
-      renew: boolean;
-      value: string | null;
-    };
+    unsignCookie(value: string): UnsignResult;
     /**
      * Manual cookie parsing method
      * @docs https://github.com/fastify/fastify-cookie#manual-cookie-parsing
@@ -39,11 +35,7 @@ declare module 'fastify' {
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(value: string): {
-      valid: boolean;
-      renew: boolean;
-      value: string | null;
-    };
+    unsignCookie(value: string): UnsignResult;
   }
 
   export type setCookieWrapper = (
@@ -82,11 +74,7 @@ declare module 'fastify' {
      * Unsigns the specified cookie using the secret provided.
      * @param value Cookie value
      */
-    unsignCookie(value: string): {
-      valid: boolean;
-      renew: boolean;
-      value: string | null;
-    };
+    unsignCookie(value: string): UnsignResult;
   }
 }
 
@@ -120,6 +108,7 @@ declare const unsign: (input: string, secret: string, algorithm?: string) => Uns
 
 export interface FastifyCookieOptions {
   secret?: string | string[] | Signer;
+  algorithm?: string;
   parseOptions?: CookieSerializeOptions;
 }
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -87,7 +87,7 @@ export interface CookieSerializeOptions {
   path?: string;
   priority?: 'low' | 'medium' | 'high';
   sameSite?: boolean | 'lax' | 'strict' | 'none';
-  secure?: boolean;
+  secure?: boolean | 'auto';
   signed?: boolean;
 }
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -102,7 +102,7 @@ interface Signer {
   unsign: (input: string) => UnsignResult;
 }
 
-declare class SignerFactory {
+declare class Signer {
   constructor (secrets: string | Array<string>, algorithm?: string)
   sign: (value: string) => string;
   unsign: (input: string) => UnsignResult;
@@ -120,4 +120,4 @@ export interface FastifyCookieOptions {
 declare const fastifyCookie: FastifyPluginCallback<NonNullable<FastifyCookieOptions>>;
 
 export default fastifyCookie;
-export { fastifyCookie, SignerFactory, sign, unsign };
+export { fastifyCookie, Signer, sign, unsign };

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -90,7 +90,12 @@ type FastifyCookiePlugin = FastifyPluginCallback<
 >;
 
 declare namespace fastifyCookie {
-  export class Signer {
+  interface SignerBase {
+    sign: (value: string) => string;
+    unsign: (input: string) => UnsignResult;
+  }
+
+  export class Signer implements SignerBase {
     constructor (secrets: string | Array<string>, algorithm?: string)
     sign: (value: string) => string;
     unsign: (input: string) => UnsignResult;
@@ -114,9 +119,9 @@ declare namespace fastifyCookie {
     parseOptions?: fastifyCookie.CookieSerializeOptions;
   }
 
-  export type Sign = (value: string, secret: string) => string;
-  export type Unsign = (input: string, secret: string) => UnsignResult;
-  export type SignerFactory = (secret: string) => Signer;
+  export type Sign = (value: string, secret: string, algorithm?: string) => string;
+  export type Unsign = (input: string, secret: string, algorithm?: string) => UnsignResult;
+  export type SignerFactory = (secrets: string | Array<string>, algorithm?: string) => SignerBase;
 
   export interface UnsignResult {
     valid: boolean;
@@ -138,7 +143,7 @@ declare namespace fastifyCookie {
   export const fastifyCookie: FastifyCookie;
 
   export interface FastifyCookieOptions {
-    secret?: string | string[] | Signer;
+    secret?: string | string[] | SignerBase;
     algorithm?: string;
     parseOptions?: CookieSerializeOptions;
   }

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -103,18 +103,20 @@ export interface CookieSerializeOptions {
   signed?: boolean;
 }
 
+type UnsignResult = {
+  valid: boolean;
+  renew: boolean;
+  value: string | null;
+};
+
 interface Signer {
   sign: (input: string) => string;
-  unsign: (input: string) => {
-    valid: boolean;
-    renew: boolean;
-    value: string | null;
-  };
+  unsign: (input: string) => UnsignResult;
 }
 
-declare const signerFactory: Signer;
-declare const sign: (value: string, secret: string) => string;
-declare const unsign: (input: string, secret: string) => string | false;
+declare function signerFactory(secret: string, algorithm?: string) : Signer;
+declare const sign: (value: string, secret: string, algorithm?: string) => string;
+declare const unsign: (input: string, secret: string, algorithm?: string) => UnsignResult;
 
 export interface FastifyCookieOptions {
   secret?: string | string[] | Signer;

--- a/plugin.js
+++ b/plugin.js
@@ -55,7 +55,8 @@ function onReqHandlerWrapper (fastify) {
 function plugin (fastify, options, next) {
   const secret = options.secret || ''
   const enableRotation = Array.isArray(secret)
-  const signer = typeof secret === 'string' || enableRotation ? signerFactory(secret) : secret
+  const algorithm = options.algorithm || 'sha256'
+  const signer = typeof secret === 'string' || enableRotation ? signerFactory(secret, algorithm) : secret
 
   fastify.decorate('parseCookie', parseCookie)
   fastify.decorate('signCookie', signCookie)

--- a/plugin.js
+++ b/plugin.js
@@ -111,14 +111,17 @@ const fastifyCookie = fp(plugin, {
  * - `import { fastifyCookie } from 'fastify-cookie'`
  * - `import fastifyCookie from 'fastify-cookie'`
  */
+fastifyCookie.signerFactory = Signer
 fastifyCookie.fastifyCookie = fastifyCookie
 fastifyCookie.default = fastifyCookie
 module.exports = fastifyCookie
 
+fastifyCookie.fastifyCookie.signerFactory = Signer
 fastifyCookie.fastifyCookie.Signer = Signer
 fastifyCookie.fastifyCookie.sign = sign
 fastifyCookie.fastifyCookie.unsign = unsign
 
+module.exports.signerFactory = Signer
 module.exports.Signer = Signer
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,7 @@
 const fp = require('fastify-plugin')
 const cookie = require('cookie')
 
-const { signerFactory, sign, unsign } = require('./signer')
+const { SignerFactory, sign, unsign } = require('./signer')
 
 function fastifyCookieSetCookie (reply, name, value, options, signer) {
   const opts = Object.assign({}, options)
@@ -56,7 +56,7 @@ function plugin (fastify, options, next) {
   const secret = options.secret || ''
   const enableRotation = Array.isArray(secret)
   const algorithm = options.algorithm || 'sha256'
-  const signer = typeof secret === 'string' || enableRotation ? signerFactory(secret, algorithm) : secret
+  const signer = typeof secret === 'string' || enableRotation ? new SignerFactory(secret, algorithm) : secret
 
   fastify.decorate('parseCookie', parseCookie)
   fastify.decorate('signCookie', signCookie)
@@ -115,10 +115,10 @@ fastifyCookie.fastifyCookie = fastifyCookie
 fastifyCookie.default = fastifyCookie
 module.exports = fastifyCookie
 
-fastifyCookie.fastifyCookie.signerFactory = signerFactory
+fastifyCookie.fastifyCookie.SignerFactory = SignerFactory
 fastifyCookie.fastifyCookie.sign = sign
 fastifyCookie.fastifyCookie.unsign = unsign
 
-module.exports.signerFactory = signerFactory
+module.exports.SignerFactory = SignerFactory
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/plugin.js
+++ b/plugin.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const { sign, unsign } = require('cookie-signature')
 const fp = require('fastify-plugin')
 const cookie = require('cookie')
 
-const signerFactory = require('./signer')
+const { signerFactory, sign, unsign } = require('./signer')
 
 function fastifyCookieSetCookie (reply, name, value, options, signer) {
   const opts = Object.assign({}, options)

--- a/plugin.js
+++ b/plugin.js
@@ -15,6 +15,15 @@ function fastifyCookieSetCookie (reply, name, value, options, signer) {
     value = signer.sign(value)
   }
 
+  if (opts.secure === 'auto') {
+    if (isConnectionSecure(reply.request)) {
+      opts.secure = true
+    } else {
+      opts.sameSite = 'lax'
+      opts.secure = false
+    }
+  }
+
   const serialized = cookie.serialize(name, value, opts)
   let setCookie = reply.getHeader('Set-Cookie')
   if (!setCookie) {
@@ -94,6 +103,13 @@ function plugin (fastify, options, next) {
   function clearCookie (name, options) {
     return fastifyCookieClearCookie(this, name, options)
   }
+}
+
+function isConnectionSecure (request) {
+  return (
+    request.raw.socket?.encrypted === true ||
+    request.headers['x-forwarded-proto'] === 'https'
+  )
 }
 
 const fastifyCookie = fp(plugin, {

--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,7 @@
 const fp = require('fastify-plugin')
 const cookie = require('cookie')
 
-const { SignerFactory, sign, unsign } = require('./signer')
+const { Signer, sign, unsign } = require('./signer')
 
 function fastifyCookieSetCookie (reply, name, value, options, signer) {
   const opts = Object.assign({}, options)
@@ -56,7 +56,7 @@ function plugin (fastify, options, next) {
   const secret = options.secret || ''
   const enableRotation = Array.isArray(secret)
   const algorithm = options.algorithm || 'sha256'
-  const signer = typeof secret === 'string' || enableRotation ? new SignerFactory(secret, algorithm) : secret
+  const signer = typeof secret === 'string' || enableRotation ? new Signer(secret, algorithm) : secret
 
   fastify.decorate('parseCookie', parseCookie)
   fastify.decorate('signCookie', signCookie)
@@ -115,10 +115,10 @@ fastifyCookie.fastifyCookie = fastifyCookie
 fastifyCookie.default = fastifyCookie
 module.exports = fastifyCookie
 
-fastifyCookie.fastifyCookie.SignerFactory = SignerFactory
+fastifyCookie.fastifyCookie.Signer = Signer
 fastifyCookie.fastifyCookie.sign = sign
 fastifyCookie.fastifyCookie.unsign = unsign
 
-module.exports.SignerFactory = SignerFactory
+module.exports.Signer = Signer
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/signer.js
+++ b/signer.js
@@ -38,7 +38,7 @@ function validateAlgorithm (algorithm) {
   }
 }
 
-Signer.prototype.sign = function (value, secret = this.signingKey, algorithm = this.algorithm) {
+function _sign (value, secret, algorithm) {
   if (typeof value !== 'string') {
     throw new TypeError('Cookie value must be provided as a string.')
   }
@@ -50,7 +50,7 @@ Signer.prototype.sign = function (value, secret = this.signingKey, algorithm = t
     .replace(/=+$/, '')
 }
 
-Signer.prototype.unsign = function (signedValue, secrets = this.secrets, algorithm = this.algorithm) {
+function _unsign (signedValue, secrets, algorithm) {
   if (typeof signedValue !== 'string') {
     throw new TypeError('Signed cookie string must be provided.')
   }
@@ -83,15 +83,20 @@ Signer.prototype.unsign = function (signedValue, secrets = this.secrets, algorit
   }
 }
 
-// create a signer-instance, with dummy secret
-const signer = new Signer(['dummy'])
+Signer.prototype.sign = function (value) {
+  return _sign(value, this.signingKey, this.algorithm)
+}
+
+Signer.prototype.unsign = function (signedValue) {
+  return _unsign(signedValue, this.secrets, this.algorithm)
+}
 
 function sign (value, secret, algorithm = 'sha256') {
   const secrets = Array.isArray(secret) ? secret : [secret]
 
   validateSecrets(secrets)
 
-  return signer.sign(value, secrets[0], algorithm)
+  return _sign(value, secrets[0], algorithm)
 }
 
 function unsign (signedValue, secret, algorithm = 'sha256') {
@@ -99,7 +104,7 @@ function unsign (signedValue, secret, algorithm = 'sha256') {
 
   validateSecrets(secrets)
 
-  return signer.unsign(signedValue, secrets, algorithm)
+  return _unsign(signedValue, secrets, algorithm)
 }
 
 module.exports = Signer

--- a/signer.js
+++ b/signer.js
@@ -91,6 +91,6 @@ function unsign (signedValue, secret, algorithm = 'sha256') {
   return signer.unsign(signedValue, secrets, algorithm)
 }
 module.exports = SignerFactory
-module.exports.signerFactory = SignerFactory
+module.exports.SignerFactory = SignerFactory
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/signer.js
+++ b/signer.js
@@ -2,90 +2,95 @@
 
 const crypto = require('crypto')
 
-function signerFactory (secret, factoryAlgorithm = 'sha256') {
-  const secrets = Array.isArray(secret) ? secret : [secret]
+function SignerFactory (secret, algorithm = 'sha256') {
+  if (!(this instanceof SignerFactory)) {
+    return new SignerFactory(secret, algorithm)
+  }
 
+  this.secrets = Array.isArray(secret) ? secret : [secret]
+  this.signingKey = this.secrets[0]
+  this.algorithm = algorithm
+
+  validateSecrets(this.secrets)
+  validateAlgorithm(this.algorithm)
+}
+
+function validateSecrets (secrets) {
   for (const secret of secrets) {
     if (typeof secret !== 'string') {
       throw new TypeError('Secret key must be a string.')
     }
   }
+}
 
-  const signingKey = secrets[0]
-
+function validateAlgorithm (algorithm) {
   // validate that the algorithm is supported by the node runtime
   try {
-    crypto.createHmac(factoryAlgorithm, signingKey)
+    crypto.createHmac(algorithm, 'dummyHmac')
   } catch (e) {
-    throw new TypeError(`Algorithm ${factoryAlgorithm} not supported.`)
+    throw new TypeError(`Algorithm ${algorithm} not supported.`)
+  }
+}
+
+SignerFactory.prototype.sign = function (value, secret = this.signingKey, algorithm = this.algorithm) {
+  if (typeof value !== 'string') {
+    throw new TypeError('Cookie value must be provided as a string.')
+  }
+  return value + '.' + crypto
+    .createHmac(algorithm, secret)
+    .update(value)
+    .digest('base64')
+    // remove base64 padding (=) as it has special meaning in cookies
+    .replace(/=+$/, '')
+}
+
+SignerFactory.prototype.unsign = function (signedValue, secrets = this.secrets, algorithm = this.algorithm) {
+  if (typeof signedValue !== 'string') {
+    throw new TypeError('Signed cookie string must be provided.')
+  }
+  const value = signedValue.slice(0, signedValue.lastIndexOf('.'))
+  const actual = Buffer.from(signedValue)
+
+  for (const secret of secrets) {
+    const expected = Buffer.from(this.sign(value, secret, algorithm))
+    if (
+      expected.length === actual.length &&
+      crypto.timingSafeEqual(expected, actual)
+    ) {
+      return {
+        valid: true,
+        renew: secret !== secrets[0],
+        value
+      }
+    }
   }
 
   return {
-    sign (value, secret = signingKey, algorithm = factoryAlgorithm) {
-      if (typeof value !== 'string') {
-        throw new TypeError('Cookie value must be provided as a string.')
-      }
-      return value + '.' + crypto
-        .createHmac(algorithm, secret)
-        .update(value)
-        .digest('base64')
-        // remove base64 padding (=) as it has special meaning in cookies
-        .replace(/=+$/, '')
-    },
-    unsign (signedValue, keys = secrets, algorithm = factoryAlgorithm) {
-      if (typeof signedValue !== 'string') {
-        throw new TypeError('Signed cookie string must be provided.')
-      }
-      const value = signedValue.slice(0, signedValue.lastIndexOf('.'))
-      const actual = Buffer.from(signedValue)
-
-      for (const key of keys) {
-        const expected = Buffer.from(this.sign(value, key, algorithm))
-        if (
-          expected.length === actual.length &&
-          crypto.timingSafeEqual(expected, actual)
-        ) {
-          return {
-            valid: true,
-            renew: key !== keys[0],
-            value
-          }
-        }
-      }
-
-      return {
-        valid: false,
-        renew: false,
-        value: null
-      }
-    }
+    valid: false,
+    renew: false,
+    value: null
   }
 }
 
 // create a signer-instance, with dummy secret
-const signer = signerFactory(['dummy'])
+const signer = new SignerFactory(['dummy'])
 
-module.exports = signerFactory
-module.exports.signerFactory = signerFactory
-module.exports.sign = function sign (value, secret, algorithm = 'sha256') {
+function sign (value, secret, algorithm = 'sha256') {
   const secrets = Array.isArray(secret) ? secret : [secret]
 
-  for (const secret of secrets) {
-    if (typeof secret !== 'string') {
-      throw new TypeError('Secret key must be a string.')
-    }
-  }
+  validateSecrets(secrets)
 
   return signer.sign(value, secrets[0], algorithm)
 }
-module.exports.unsign = function unsign (signedValue, secret, algorithm = 'sha256') {
+
+function unsign (signedValue, secret, algorithm = 'sha256') {
   const secrets = Array.isArray(secret) ? secret : [secret]
 
-  for (const secret of secrets) {
-    if (typeof secret !== 'string') {
-      throw new TypeError('Secret key must be a string.')
-    }
-  }
+  validateSecrets(secrets)
 
   return signer.unsign(signedValue, secrets, algorithm)
 }
+module.exports = SignerFactory
+module.exports.signerFactory = SignerFactory
+module.exports.sign = sign
+module.exports.unsign = unsign

--- a/signer.js
+++ b/signer.js
@@ -1,5 +1,11 @@
 'use strict'
 
+// Inspired by node-cookie-signature
+// https://github.com/tj/node-cookie-signature
+//
+// The MIT License
+// Copyright (c) 2012–2022 LearnBoost <tj@learnboost.com> and other contributors;
+
 const crypto = require('crypto')
 
 function Signer (secrets, algorithm = 'sha256') {

--- a/signer.js
+++ b/signer.js
@@ -36,7 +36,6 @@ function signerFactory (secret, factoryAlgorithm = 'sha256') {
       if (typeof signedValue !== 'string') {
         throw new TypeError('Signed cookie string must be provided.')
       }
-      (Array.isArray(keys) === false) && (keys = [keys])
       let valid = false
       let renew = false
       let value = null
@@ -87,5 +86,5 @@ module.exports.unsign = function unsign (signedValue, secret, algorithm = 'sha25
     }
   }
 
-  return signer.unsign(signedValue, secret, algorithm)
+  return signer.unsign(signedValue, secrets, algorithm)
 }

--- a/signer.js
+++ b/signer.js
@@ -62,8 +62,7 @@ function signerFactory (secret, factoryAlgorithm = 'sha256') {
   }
 }
 
-// create a signer-instance, with dummy secret, as the secret is validated by
-// the sign and unsign functions
+// create a signer-instance, with dummy secret
 const signer = signerFactory(['dummy'])
 
 module.exports = signerFactory

--- a/signer.js
+++ b/signer.js
@@ -49,10 +49,15 @@ SignerFactory.prototype.unsign = function (signedValue, secrets = this.secrets, 
     throw new TypeError('Signed cookie string must be provided.')
   }
   const value = signedValue.slice(0, signedValue.lastIndexOf('.'))
-  const actual = Buffer.from(signedValue)
+  const actual = Buffer.from(signedValue.slice(signedValue.lastIndexOf('.') + 1))
 
   for (const secret of secrets) {
-    const expected = Buffer.from(this.sign(value, secret, algorithm))
+    const expected = Buffer.from(crypto
+      .createHmac(algorithm, secret)
+      .update(value)
+      .digest('base64')
+      // remove base64 padding (=) as it has special meaning in cookies
+      .replace(/=+$/, ''))
     if (
       expected.length === actual.length &&
       crypto.timingSafeEqual(expected, actual)

--- a/signer.js
+++ b/signer.js
@@ -36,26 +36,28 @@ function signerFactory (secret, factoryAlgorithm = 'sha256') {
       if (typeof signedValue !== 'string') {
         throw new TypeError('Signed cookie string must be provided.')
       }
-      let valid = false
-      let renew = false
-      let value = null
-      const tentativeValue = signedValue.slice(0, signedValue.lastIndexOf('.'))
+      const value = signedValue.slice(0, signedValue.lastIndexOf('.'))
       const actual = Buffer.from(signedValue)
 
       for (const key of keys) {
-        const expected = Buffer.from(this.sign(tentativeValue, key, algorithm))
+        const expected = Buffer.from(this.sign(value, key, algorithm))
         if (
           expected.length === actual.length &&
           crypto.timingSafeEqual(expected, actual)
         ) {
-          valid = true
-          renew = key !== keys[0]
-          value = tentativeValue
-          break
+          return {
+            valid: true,
+            renew: key !== keys[0],
+            value
+          }
         }
       }
 
-      return { valid, renew, value }
+      return {
+        valid: false,
+        renew: false,
+        value: null
+      }
     }
   }
 }

--- a/signer.js
+++ b/signer.js
@@ -8,6 +8,8 @@
 
 const crypto = require('crypto')
 
+const base64PaddingRE = /=/g
+
 function Signer (secrets, algorithm = 'sha256') {
   if (!(this instanceof Signer)) {
     return new Signer(secrets, algorithm)
@@ -47,7 +49,7 @@ function _sign (value, secret, algorithm) {
     .update(value)
     .digest('base64')
     // remove base64 padding (=) as it has special meaning in cookies
-    .replace(/=+$/, '')
+    .replace(base64PaddingRE, '')
 }
 
 function _unsign (signedValue, secrets, algorithm) {
@@ -63,7 +65,7 @@ function _unsign (signedValue, secrets, algorithm) {
       .update(value)
       .digest('base64')
       // remove base64 padding (=) as it has special meaning in cookies
-      .replace(/=+$/, ''))
+      .replace(base64PaddingRE, ''))
     if (
       expected.length === actual.length &&
       crypto.timingSafeEqual(expected, actual)

--- a/signer.js
+++ b/signer.js
@@ -2,12 +2,12 @@
 
 const crypto = require('crypto')
 
-function SignerFactory (secret, algorithm = 'sha256') {
+function SignerFactory (secrets, algorithm = 'sha256') {
   if (!(this instanceof SignerFactory)) {
-    return new SignerFactory(secret, algorithm)
+    return new SignerFactory(secrets, algorithm)
   }
 
-  this.secrets = Array.isArray(secret) ? secret : [secret]
+  this.secrets = Array.isArray(secrets) ? secrets : [secrets]
   this.signingKey = this.secrets[0]
   this.algorithm = algorithm
 

--- a/signer.js
+++ b/signer.js
@@ -2,9 +2,9 @@
 
 const crypto = require('crypto')
 
-function SignerFactory (secrets, algorithm = 'sha256') {
-  if (!(this instanceof SignerFactory)) {
-    return new SignerFactory(secrets, algorithm)
+function Signer (secrets, algorithm = 'sha256') {
+  if (!(this instanceof Signer)) {
+    return new Signer(secrets, algorithm)
   }
 
   this.secrets = Array.isArray(secrets) ? secrets : [secrets]
@@ -32,7 +32,7 @@ function validateAlgorithm (algorithm) {
   }
 }
 
-SignerFactory.prototype.sign = function (value, secret = this.signingKey, algorithm = this.algorithm) {
+Signer.prototype.sign = function (value, secret = this.signingKey, algorithm = this.algorithm) {
   if (typeof value !== 'string') {
     throw new TypeError('Cookie value must be provided as a string.')
   }
@@ -44,7 +44,7 @@ SignerFactory.prototype.sign = function (value, secret = this.signingKey, algori
     .replace(/=+$/, '')
 }
 
-SignerFactory.prototype.unsign = function (signedValue, secrets = this.secrets, algorithm = this.algorithm) {
+Signer.prototype.unsign = function (signedValue, secrets = this.secrets, algorithm = this.algorithm) {
   if (typeof signedValue !== 'string') {
     throw new TypeError('Signed cookie string must be provided.')
   }
@@ -78,7 +78,7 @@ SignerFactory.prototype.unsign = function (signedValue, secrets = this.secrets, 
 }
 
 // create a signer-instance, with dummy secret
-const signer = new SignerFactory(['dummy'])
+const signer = new Signer(['dummy'])
 
 function sign (value, secret, algorithm = 'sha256') {
   const secrets = Array.isArray(secret) ? secret : [secret]
@@ -95,7 +95,7 @@ function unsign (signedValue, secret, algorithm = 'sha256') {
 
   return signer.unsign(signedValue, secrets, algorithm)
 }
-module.exports = SignerFactory
-module.exports.SignerFactory = SignerFactory
+module.exports = Signer
+module.exports.Signer = Signer
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/signer.js
+++ b/signer.js
@@ -95,7 +95,9 @@ function unsign (signedValue, secret, algorithm = 'sha256') {
 
   return signer.unsign(signedValue, secrets, algorithm)
 }
+
 module.exports = Signer
+module.exports.signerFactory = Signer
 module.exports.Signer = Signer
 module.exports.sign = sign
 module.exports.unsign = unsign

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const test = tap.test
 const Fastify = require('fastify')
 const sinon = require('sinon')
-const signer = require('../signer')
+const { sign, unsign } = require('../signer')
 const plugin = require('../')
 
 test('cookies get set correctly', (t) => {
@@ -151,7 +151,7 @@ test('share options for setCookie and clearCookie', (t) => {
     const cookies = res.cookies
     t.equal(cookies.length, 2)
     t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, signer.sign('foo', secret))
+    t.equal(cookies[0].value, sign('foo', secret))
     t.equal(cookies[0].maxAge, 36000)
 
     t.equal(cookies[1].name, 'foo')
@@ -190,7 +190,7 @@ test('expires should not be overridden in clearCookie', (t) => {
     const cookies = res.cookies
     t.equal(cookies.length, 2)
     t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, signer.sign('foo', secret))
+    t.equal(cookies[0].value, sign('foo', secret))
     const expires = new Date(cookies[0].expires)
     t.ok(expires < new Date(Date.now() + 5000))
 
@@ -378,7 +378,7 @@ test('cookies signature', (t) => {
       const cookies = res.cookies
       t.equal(cookies.length, 1)
       t.equal(cookies[0].name, 'foo')
-      t.same(signer.unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
+      t.same(unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
     })
   })
 
@@ -406,7 +406,7 @@ test('cookies signature', (t) => {
       const cookies = res.cookies
       t.equal(cookies.length, 1)
       t.equal(cookies[0].name, 'foo')
-      t.same(signer.unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
+      t.same(unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
     })
   })
 
@@ -427,7 +427,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', secret)}`
+        cookie: `foo=${sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -452,7 +452,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', secret)}`
+        cookie: `foo=${sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -477,7 +477,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', secret)}`
+        cookie: `foo=${sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -503,7 +503,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', secret2)}`
+        cookie: `foo=${sign('foo', secret2)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -529,7 +529,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', secret2)}`
+        cookie: `foo=${sign('foo', secret2)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -555,7 +555,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', 'invalid-secret')}`
+        cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
     }, (err, res) => {
       t.error(err)
@@ -581,7 +581,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${signer.sign('foo', 'invalid-secret')}`
+        cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
     }, (err, res) => {
       t.error(err)

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -4,7 +4,7 @@ const tap = require('tap')
 const test = tap.test
 const Fastify = require('fastify')
 const sinon = require('sinon')
-const cookieSignature = require('cookie-signature')
+const signer = require('../signer')
 const plugin = require('../')
 
 test('cookies get set correctly', (t) => {
@@ -151,7 +151,7 @@ test('share options for setCookie and clearCookie', (t) => {
     const cookies = res.cookies
     t.equal(cookies.length, 2)
     t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, cookieSignature.sign('foo', secret))
+    t.equal(cookies[0].value, signer.sign('foo', secret))
     t.equal(cookies[0].maxAge, 36000)
 
     t.equal(cookies[1].name, 'foo')
@@ -190,7 +190,7 @@ test('expires should not be overridden in clearCookie', (t) => {
     const cookies = res.cookies
     t.equal(cookies.length, 2)
     t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, cookieSignature.sign('foo', secret))
+    t.equal(cookies[0].value, signer.sign('foo', secret))
     const expires = new Date(cookies[0].expires)
     t.ok(expires < new Date(Date.now() + 5000))
 
@@ -378,7 +378,7 @@ test('cookies signature', (t) => {
       const cookies = res.cookies
       t.equal(cookies.length, 1)
       t.equal(cookies[0].name, 'foo')
-      t.equal(cookieSignature.unsign(cookies[0].value, secret), 'foo')
+      t.same(signer.unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
     })
   })
 
@@ -406,7 +406,7 @@ test('cookies signature', (t) => {
       const cookies = res.cookies
       t.equal(cookies.length, 1)
       t.equal(cookies[0].name, 'foo')
-      t.equal(cookieSignature.unsign(cookies[0].value, secret1), 'cookieVal') // decode using first key
+      t.same(signer.unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
     })
   })
 
@@ -427,7 +427,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', secret)}`
+        cookie: `foo=${signer.sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -452,7 +452,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', secret)}`
+        cookie: `foo=${signer.sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -477,7 +477,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', secret)}`
+        cookie: `foo=${signer.sign('foo', secret)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -503,7 +503,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', secret2)}`
+        cookie: `foo=${signer.sign('foo', secret2)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -529,7 +529,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', secret2)}`
+        cookie: `foo=${signer.sign('foo', secret2)}`
       }
     }, (err, res) => {
       t.error(err)
@@ -555,7 +555,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', 'invalid-secret')}`
+        cookie: `foo=${signer.sign('foo', 'invalid-secret')}`
       }
     }, (err, res) => {
       t.error(err)
@@ -581,7 +581,7 @@ test('cookies signature', (t) => {
       method: 'GET',
       url: '/test1',
       headers: {
-        cookie: `foo=${cookieSignature.sign('foo', 'invalid-secret')}`
+        cookie: `foo=${signer.sign('foo', 'invalid-secret')}`
       }
     }, (err, res) => {
       t.error(err)

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -104,6 +104,10 @@ const appWithImplicitHttpSigned = fastify();
 appWithImplicitHttpSigned.register(cookie, {
   secret: 'testsecret',
 });
+appWithImplicitHttpSigned.register(cookie, {
+  secret: 'testsecret',
+  algorithm: 'sha512'
+});
 appWithImplicitHttpSigned.after(() => {
   server.get('/', (request, reply) => {
     appWithImplicitHttpSigned.unsignCookie(request.cookies.test!);

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,13 +1,10 @@
-import fastify, { FastifyInstance, FastifyPluginCallback, FastifyReply, setCookieWrapper } from 'fastify';
-import { Server } from 'http';
+import cookie from '../plugin';
 import { expectType } from 'tsd';
 import * as fastifyCookieStar from '..';
-import fastifyCookieDefault, {
-  fastifyCookie as fastifyCookieNamed
-} from '..';
-import cookie, { FastifyCookieOptions } from '../plugin';
-
 import fastifyCookieCjsImport = require('..');
+import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed  } from '..';
+import fastify, { FastifyInstance,  FastifyReply, setCookieWrapper } from 'fastify';
+
 const fastifyCookieCjs = require('..');
 
 const app: FastifyInstance = fastify();
@@ -19,15 +16,23 @@ app.register(fastifyCookieCjsImport.fastifyCookie);
 app.register(fastifyCookieStar.default);
 app.register(fastifyCookieStar.fastifyCookie);
 
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieNamed);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieDefault);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.default);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieCjsImport.fastifyCookie);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(fastifyCookieStar.default);
-expectType<FastifyPluginCallback<FastifyCookieOptions, Server>>(
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieNamed);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieDefault);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.default);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.fastifyCookie);
+expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieStar.default);
+expectType<fastifyCookieStar.FastifyCookie>(
   fastifyCookieStar.fastifyCookie
 );
 expectType<any>(fastifyCookieCjs);
+
+expectType<fastifyCookieStar.Sign>(fastifyCookieDefault.sign);
+expectType<fastifyCookieStar.Unsign>(fastifyCookieDefault.unsign);
+expectType<fastifyCookieStar.SignerFactory >(fastifyCookieDefault.signerFactory );
+
+expectType<fastifyCookieStar.Sign>(fastifyCookieNamed.sign);
+expectType<fastifyCookieStar.Unsign>(fastifyCookieNamed.unsign);
+expectType<fastifyCookieStar.SignerFactory >(fastifyCookieNamed.signerFactory );
 
 const server = fastify();
 

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -194,8 +194,8 @@ appWithCustomSigner.after(() => {
   })
 })
 
-new fastifyCookieStar.SignerFactory('secretString')
-new fastifyCookieStar.SignerFactory(['secretStringInArray'])
-const signer = new fastifyCookieStar.SignerFactory(['secretStringInArray'], 'sha256')
+new fastifyCookieStar.Signer('secretString')
+new fastifyCookieStar.Signer(['secretStringInArray'])
+const signer = new fastifyCookieStar.Signer(['secretStringInArray'], 'sha256')
 signer.sign('Lorem Ipsum')
 signer.unsign('Lorem Ipsum')

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -193,3 +193,9 @@ appWithCustomSigner.after(() => {
     reply.send({ hello: 'world' })
   })
 })
+
+new fastifyCookieStar.SignerFactory('secretString')
+new fastifyCookieStar.SignerFactory(['secretStringInArray'])
+const signer = new fastifyCookieStar.SignerFactory(['secretStringInArray'], 'sha256')
+signer.sign('Lorem Ipsum')
+signer.unsign('Lorem Ipsum')

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const sinon = require('sinon')
+const crypto = require('crypto')
 const { SignerFactory, sign, unsign } = require('../signer')
 
 test('default', t => {
@@ -71,7 +72,7 @@ test('key rotation', (t) => {
   const secret2 = 'my-secret-2'
   const secret3 = 'my-secret-3'
   const signer = SignerFactory([secret1, secret2, secret3])
-  const signSpy = sinon.spy(signer, 'sign')
+  const signSpy = sinon.spy(crypto, 'createHmac')
 
   t.beforeEach(() => {
     signSpy.resetHistory()

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -120,7 +120,7 @@ test('signerFactory', t => {
 
   t.test('signerFactory handles algorithm properly', (t) => {
     t.plan(3)
-    t.throws(() => signerFactory('secret', 'invalid'))
+    t.throws(() => signerFactory('secret', 'invalid'), 'Algorithm invalid not supported.')
     t.doesNotThrow(() => signerFactory('secret', 'sha512'))
     t.doesNotThrow(() => signerFactory('secret', 'sha256'))
   })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -90,7 +90,7 @@ test('key rotation', (t) => {
   t.test('signer.unsign tries to decode using all keys till it finds', (t) => {
     t.plan(4)
 
-    const input = signer.sign('some-value', secret2)
+    const input = sign('some-value', secret2)
     signSpy.resetHistory()
     const result = signer.unsign(input)
 
@@ -103,7 +103,7 @@ test('key rotation', (t) => {
   t.test('signer.unsign failure response', (t) => {
     t.plan(4)
 
-    const input = signer.sign('some-value', 'invalid-secret')
+    const input = sign('some-value', 'invalid-secret')
     signSpy.resetHistory()
     const result = signer.unsign(input)
 

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -2,13 +2,13 @@
 
 const { test } = require('tap')
 const sinon = require('sinon')
-const { signerFactory, sign, unsign } = require('../signer')
+const { SignerFactory, sign, unsign } = require('../signer')
 
 test('default', t => {
   t.plan(5)
 
   const secret = 'my-secret'
-  const signer = signerFactory(secret)
+  const signer = SignerFactory(secret)
 
   t.test('signer.sign should throw if there is no value provided', (t) => {
     t.plan(1)
@@ -70,7 +70,7 @@ test('key rotation', (t) => {
   const secret1 = 'my-secret-1'
   const secret2 = 'my-secret-2'
   const secret3 = 'my-secret-3'
-  const signer = signerFactory([secret1, secret2, secret3])
+  const signer = SignerFactory([secret1, secret2, secret3])
   const signSpy = sinon.spy(signer, 'sign')
 
   t.beforeEach(() => {
@@ -118,16 +118,16 @@ test('signerFactory', t => {
 
   t.test('signerFactory needs a string as secret', (t) => {
     t.plan(4)
-    t.throws(() => signerFactory(1), 'Secret key must be a string.')
-    t.throws(() => signerFactory(undefined), 'Secret key must be a string.')
-    t.doesNotThrow(() => signerFactory('secret'))
-    t.doesNotThrow(() => signerFactory(['secret']))
+    t.throws(() => SignerFactory(1), 'Secret key must be a string.')
+    t.throws(() => SignerFactory(undefined), 'Secret key must be a string.')
+    t.doesNotThrow(() => SignerFactory('secret'))
+    t.doesNotThrow(() => SignerFactory(['secret']))
   })
 
   t.test('signerFactory handles algorithm properly', (t) => {
     t.plan(3)
-    t.throws(() => signerFactory('secret', 'invalid'), 'Algorithm invalid not supported.')
-    t.doesNotThrow(() => signerFactory('secret', 'sha512'))
-    t.doesNotThrow(() => signerFactory('secret', 'sha256'))
+    t.throws(() => SignerFactory('secret', 'invalid'), 'Algorithm invalid not supported.')
+    t.doesNotThrow(() => SignerFactory('secret', 'sha512'))
+    t.doesNotThrow(() => SignerFactory('secret', 'sha256'))
   })
 })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -5,10 +5,16 @@ const sinon = require('sinon')
 const { signerFactory, sign, unsign } = require('../signer')
 
 test('default', t => {
-  t.plan(4)
+  t.plan(5)
 
   const secret = 'my-secret'
   const signer = signerFactory(secret)
+
+  t.test('signer.sign should throw if there is no value provided', (t) => {
+    t.plan(1)
+
+    t.throws(() => signer.sign(undefined), 'Cookie value must be provided as a string.')
+  })
 
   t.test('signer.sign', (t) => {
     t.plan(2)
@@ -16,8 +22,8 @@ test('default', t => {
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, signer.sign(input, secret))
-    t.throws(() => signer.sign(undefined), 'Cookie value must be provided as a string.')
+    t.equal(result, sign(input, secret))
+    t.throws(() => sign(undefined), 'Cookie value must be provided as a string.')
   })
 
   t.test('sign', (t) => {
@@ -77,7 +83,7 @@ test('key rotation', (t) => {
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, signer.sign(input, secret1))
+    t.equal(result, sign(input, secret1))
   })
 
   t.test('signer.unsign tries to decode using all keys till it finds', (t) => {

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -3,13 +3,13 @@
 const { test } = require('tap')
 const sinon = require('sinon')
 const crypto = require('crypto')
-const { SignerFactory, sign, unsign } = require('../signer')
+const { Signer, sign, unsign } = require('../signer')
 
 test('default', t => {
   t.plan(5)
 
   const secret = 'my-secret'
-  const signer = SignerFactory(secret)
+  const signer = Signer(secret)
 
   t.test('signer.sign should throw if there is no value provided', (t) => {
     t.plan(1)
@@ -71,7 +71,7 @@ test('key rotation', (t) => {
   const secret1 = 'my-secret-1'
   const secret2 = 'my-secret-2'
   const secret3 = 'my-secret-3'
-  const signer = SignerFactory([secret1, secret2, secret3])
+  const signer = Signer([secret1, secret2, secret3])
   const signSpy = sinon.spy(crypto, 'createHmac')
 
   t.beforeEach(() => {
@@ -114,21 +114,21 @@ test('key rotation', (t) => {
   })
 })
 
-test('signerFactory', t => {
+test('Signer', t => {
   t.plan(2)
 
-  t.test('signerFactory needs a string as secret', (t) => {
+  t.test('Signer needs a string as secret', (t) => {
     t.plan(4)
-    t.throws(() => SignerFactory(1), 'Secret key must be a string.')
-    t.throws(() => SignerFactory(undefined), 'Secret key must be a string.')
-    t.doesNotThrow(() => SignerFactory('secret'))
-    t.doesNotThrow(() => SignerFactory(['secret']))
+    t.throws(() => Signer(1), 'Secret key must be a string.')
+    t.throws(() => Signer(undefined), 'Secret key must be a string.')
+    t.doesNotThrow(() => Signer('secret'))
+    t.doesNotThrow(() => Signer(['secret']))
   })
 
-  t.test('signerFactory handles algorithm properly', (t) => {
+  t.test('Signer handles algorithm properly', (t) => {
     t.plan(3)
-    t.throws(() => SignerFactory('secret', 'invalid'), 'Algorithm invalid not supported.')
-    t.doesNotThrow(() => SignerFactory('secret', 'sha512'))
-    t.doesNotThrow(() => SignerFactory('secret', 'sha256'))
+    t.throws(() => Signer('secret', 'invalid'), 'Algorithm invalid not supported.')
+    t.doesNotThrow(() => Signer('secret', 'sha512'))
+    t.doesNotThrow(() => Signer('secret', 'sha256'))
   })
 })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -2,33 +2,60 @@
 
 const { test } = require('tap')
 const sinon = require('sinon')
-const cookieSignature = require('cookie-signature')
-const signerFactory = require('../signer')
+const { signerFactory, sign, unsign } = require('../signer')
 
-test('default', (t) => {
-  t.plan(2)
+test('default', t => {
+  t.plan(4)
 
   const secret = 'my-secret'
   const signer = signerFactory(secret)
 
   t.test('signer.sign', (t) => {
-    t.plan(1)
+    t.plan(2)
 
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, cookieSignature.sign(input, secret))
+    t.equal(result, signer.sign(input, secret))
+    t.throws(() => signer.sign(undefined), 'Cookie value must be provided as a string.')
+  })
+
+  t.test('sign', (t) => {
+    t.plan(3)
+
+    const input = 'some-value'
+    const result = signer.sign(input)
+
+    t.equal(result, sign(input, secret))
+    t.equal(result, sign(input, [secret]))
+
+    t.throws(() => sign(undefined), 'Cookie value must be provided as a string.')
   })
 
   t.test('signer.unsign', (t) => {
-    t.plan(3)
+    t.plan(4)
 
-    const input = cookieSignature.sign('some-value', secret)
+    const input = signer.sign('some-value', secret)
     const result = signer.unsign(input)
 
     t.equal(result.valid, true)
     t.equal(result.renew, false)
     t.equal(result.value, 'some-value')
+    t.throws(() => signer.unsign(undefined), 'Signed cookie string must be provided.')
+  })
+
+  t.test('unsign', (t) => {
+    t.plan(6)
+
+    const input = sign('some-value', secret)
+    const result = unsign(input, secret)
+
+    t.equal(result.valid, true)
+    t.equal(result.renew, false)
+    t.equal(result.value, 'some-value')
+    t.same(result, unsign(input, [secret]))
+    t.throws(() => unsign(undefined), 'Secret key must be a string.')
+    t.throws(() => unsign(undefined, secret), 'Signed cookie string must be provided.')
   })
 })
 
@@ -38,10 +65,10 @@ test('key rotation', (t) => {
   const secret2 = 'my-secret-2'
   const secret3 = 'my-secret-3'
   const signer = signerFactory([secret1, secret2, secret3])
-  const unsignSpy = sinon.spy(cookieSignature, 'unsign')
+  const signSpy = sinon.spy(signer, 'sign')
 
   t.beforeEach(() => {
-    unsignSpy.resetHistory()
+    signSpy.resetHistory()
   })
 
   t.test('signer.sign always signs using first key', (t) => {
@@ -50,30 +77,51 @@ test('key rotation', (t) => {
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, cookieSignature.sign(input, secret1))
+    t.equal(result, signer.sign(input, secret1))
   })
 
   t.test('signer.unsign tries to decode using all keys till it finds', (t) => {
     t.plan(4)
 
-    const input = cookieSignature.sign('some-value', secret2)
+    const input = signer.sign('some-value', secret2)
+    signSpy.resetHistory()
     const result = signer.unsign(input)
 
     t.equal(result.valid, true)
     t.equal(result.renew, true)
     t.equal(result.value, 'some-value')
-    t.equal(unsignSpy.callCount, 2) // should have returned early when the right key was found
+    t.equal(signSpy.callCount, 2) // should have returned early when the right key was found
   })
 
   t.test('signer.unsign failure response', (t) => {
     t.plan(4)
 
-    const input = cookieSignature.sign('some-value', 'invalid-secret')
+    const input = signer.sign('some-value', 'invalid-secret')
+    signSpy.resetHistory()
     const result = signer.unsign(input)
 
     t.equal(result.valid, false)
     t.equal(result.renew, false)
     t.equal(result.value, null)
-    t.equal(unsignSpy.callCount, 3) // should have tried all 3
+    t.equal(signSpy.callCount, 3) // should have tried all 3
+  })
+})
+
+test('signerFactory', t => {
+  t.plan(2)
+
+  t.test('signerFactory needs a string as secret', (t) => {
+    t.plan(4)
+    t.throws(() => signerFactory(1), 'Secret key must be a string.')
+    t.throws(() => signerFactory(undefined), 'Secret key must be a string.')
+    t.doesNotThrow(() => signerFactory('secret'))
+    t.doesNotThrow(() => signerFactory(['secret']))
+  })
+
+  t.test('signerFactory handles algorithm properly', (t) => {
+    t.plan(3)
+    t.throws(() => signerFactory('secret', 'invalid'))
+    t.doesNotThrow(() => signerFactory('secret', 'sha512'))
+    t.doesNotThrow(() => signerFactory('secret', 'sha256'))
   })
 })


### PR DESCRIPTION
I know you maybe dont like to integrate the cookie-signature package, but I think it has some benefits.

- We can specify which algorithm we want to use for the signing. So you can specify e.g. sha512 or sha1 instead of sha256
- standalone unsign-function will be able to handle multiple secrets and will return an UnsignResult Object, basically unifying the behaviour of unsign from the signerFactory with the standalone unsign-Function 
- because the return value of the unsign function is changed, it probably means a semver major

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
