### PR TITLE
add secure: 'auto' Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ with a value of `'foo'` on the cookie path `/`.
 + `name`: a string name for the cookie to be set
 + `value`: a string value for the cookie
 + `options`: an options object as described in the [cookie serialize][cs] documentation
-  with an extra param "signed" for signed cookie and the param "secure" also accepting the value "auto"
++ `options.signed`: the cookie should be signed
++ `options.secure`: if set to `true` it will set the Secure-flag. If it is set to `"auto"` Secure-flag is set when the connection is using tls.
 
 #### Securing the cookie
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ with a value of `'foo'` on the cookie path `/`.
 + `name`: a string name for the cookie to be set
 + `value`: a string value for the cookie
 + `options`: an options object as described in the [cookie serialize][cs] documentation
-  with a extra param "signed" for signed cookie
+  with an extra param "signed" for signed cookie and the param "secure" also accepting the value "auto"
 
 #### Securing the cookie
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -99,7 +99,7 @@ export interface CookieSerializeOptions {
   path?: string;
   priority?: 'low' | 'medium' | 'high';
   sameSite?: boolean | 'lax' | 'strict' | 'none';
-  secure?: boolean;
+  secure?: boolean | 'auto';
   signed?: boolean;
 }
 

--- a/plugin.js
+++ b/plugin.js
@@ -16,6 +16,15 @@ function fastifyCookieSetCookie (reply, name, value, options, signer) {
     value = signer.sign(value)
   }
 
+  if (opts.secure === 'auto') {
+    if (isConnectionSecure(reply.request)) {
+      opts.secure = true
+    } else {
+      opts.sameSite = 'Lax'
+      opts.secure = false
+    }
+  }
+
   const serialized = cookie.serialize(name, value, opts)
   let setCookie = reply.getHeader('Set-Cookie')
   if (!setCookie) {
@@ -94,6 +103,13 @@ function plugin (fastify, options, next) {
   function clearCookie (name, options) {
     return fastifyCookieClearCookie(this, name, options)
   }
+}
+
+function isConnectionSecure (request) {
+  return (
+    request.raw.socket?.encrypted === true ||
+    request.headers['x-forwarded-proto'] === 'https'
+  )
 }
 
 const fastifyCookie = fp(plugin, {

--- a/plugin.js
+++ b/plugin.js
@@ -20,7 +20,7 @@ function fastifyCookieSetCookie (reply, name, value, options, signer) {
     if (isConnectionSecure(reply.request)) {
       opts.secure = true
     } else {
-      opts.sameSite = 'Lax'
+      opts.sameSite = 'lax'
       opts.secure = false
     }
   }


### PR DESCRIPTION
This functionality is basically taken from @fastify/session https://github.com/fastify/session/blob/b1fc11c6fbb16c63a1884f202fcd030ecdb18a07/lib/cookie.js#L17

On the long run, we can remove the cookie class from @fastify/session.
 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
