### PR TITLE
feat: sign and unsign decorators are not set, when secret-option is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ fastify.register(require('@fastify/cookie'), {
 
 ### Manual cookie unsigning
 
-The method `unsignCookie(value)` is added to the `fastify` instance and the `reply` object
-via the Fastify `decorate` & `decorateReply` APIs. Using it on a signed cookie will call the
-the provided signer's (or the default signer if no custom implementation is provided) `unsign` method on the cookie.
+The method `unsignCookie(value)` is added to the `fastify` instance, to the `request` and the `reply` object
+via the Fastify `decorate`, `decorateRequest` and `decorateReply` APIs, if a secret was provided as option.
+Using it on a signed cookie will call the the provided signer's (or the default signer if no custom implementation is provided) `unsign` method on the cookie.
 
 **Example:**
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.4.0",
   "description": "Plugin for fastify to add support for cookies",
   "main": "plugin.js",
-  "types": "plugin.d.ts",
+  "types": "types/plugin.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
     "lint:ci": "standard",
@@ -42,13 +42,12 @@
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^18.0.0",
     "benchmark": "^2.1.4",
-    "fastify": "^4.0.0-rc.2",
+    "fastify": "^4.0.0",
     "sinon": "^14.0.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.0.0",
-    "tsd": "^0.22.0",
-    "typescript": "^4.5.5"
+    "tsd": "^0.22.0"
   },
   "dependencies": {
     "cookie": "^0.5.0",

--- a/plugin.js
+++ b/plugin.js
@@ -68,15 +68,23 @@ function plugin (fastify, options, next) {
   const signer = typeof secret === 'string' || enableRotation ? new Signer(secret, algorithm) : secret
 
   fastify.decorate('parseCookie', parseCookie)
-  fastify.decorate('signCookie', signCookie)
-  fastify.decorate('unsignCookie', unsignCookie)
+
+  if (secret !== '') {
+    fastify.decorate('signCookie', signCookie)
+    fastify.decorate('unsignCookie', unsignCookie)
+
+    fastify.decorateRequest('signCookie', signCookie)
+    fastify.decorateRequest('unsignCookie', unsignCookie)
+
+    fastify.decorateReply('signCookie', signCookie)
+    fastify.decorateReply('unsignCookie', unsignCookie)
+  }
 
   fastify.decorateRequest('cookies', null)
-  fastify.decorateRequest('unsignCookie', unsignCookie)
-  fastify.decorateReply('setCookie', setCookie)
   fastify.decorateReply('cookie', setCookie)
+
+  fastify.decorateReply('setCookie', setCookie)
   fastify.decorateReply('clearCookie', clearCookie)
-  fastify.decorateReply('unsignCookie', unsignCookie)
 
   fastify.addHook('onRequest', onReqHandlerWrapper(fastify))
 

--- a/plugin.js
+++ b/plugin.js
@@ -62,14 +62,14 @@ function onReqHandlerWrapper (fastify) {
 }
 
 function plugin (fastify, options, next) {
-  const secret = options.secret || ''
+  const secret = options.secret
   const enableRotation = Array.isArray(secret)
   const algorithm = options.algorithm || 'sha256'
   const signer = typeof secret === 'string' || enableRotation ? new Signer(secret, algorithm) : secret
 
   fastify.decorate('parseCookie', parseCookie)
 
-  if (secret !== '') {
+  if (typeof secret !== 'undefined') {
     fastify.decorate('signCookie', signCookie)
     fastify.decorate('unsignCookie', unsignCookie)
 

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -3,12 +3,7 @@
 import { FastifyPluginCallback } from "fastify";
 
 declare module "fastify" {
-  interface FastifyInstance {
-    /**
-     * Unsigns the specified cookie using the secret provided.
-     * @param value Cookie value
-     */
-    unsignCookie(value: string): fastifyCookie.UnsignResult;
+  interface FastifyInstance extends SignerMethods {
     /**
      * Manual cookie parsing method
      * @docs https://github.com/fastify/fastify-cookie#manual-cookie-parsing
@@ -17,22 +12,31 @@ declare module "fastify" {
     parseCookie(cookieHeader: string): {
       [key: string]: string;
     };
-    /**
-     * Manual cookie signing method
-     * @docs https://github.com/fastify/fastify-cookie#manual-cookie-parsing
-     * @param value cookie value
-     */
-    signCookie(value: string): string;
   }
 
-  interface FastifyRequest {
+  interface FastifyRequest extends SignerMethods {
     /**
      * Request cookies
      */
     cookies: { [cookieName: string]: string | undefined };
+  }
+
+  interface FastifyReply extends SignerMethods {
+    /**
+     * Request cookies
+     */
+    cookies: { [cookieName: string]: string | undefined };
+  }
+
+  interface SignerMethods {
+    /**
+     * Signs the specified cookie using the secret/signer provided.
+     * @param value cookie value
+     */
+     signCookie(value: string): string;
 
     /**
-     * Unsigns the specified cookie using the secret provided.
+     * Unsigns the specified cookie using the secret/signer provided.
      * @param value Cookie value
      */
     unsignCookie(value: string): fastifyCookie.UnsignResult;
@@ -102,15 +106,22 @@ declare namespace fastifyCookie {
   }
 
   export interface CookieSerializeOptions {
+    /**  The `Domain` attribute. */
     domain?: string;
     encode?(val: string): string;
+    /**  The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used. */
     expires?: Date;
+    /**  The `boolean` value of the `HttpOnly` attribute. Defaults to true. */
     httpOnly?: boolean;
+    /**  A `number` in milliseconds that specifies the `Expires` attribute by adding the specified milliseconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used. */
     maxAge?: number;
+    /**  The `Path` attribute. Defaults to `/` (the root path).  */
     path?: string;
     priority?: "low" | "medium" | "high";
-    sameSite?: boolean | "lax" | "strict" | "none";
-    secure?: boolean;
+    /** A `boolean` or one of the `SameSite` string attributes. E.g.: `lax`, `node` or `strict`.  */
+    sameSite?: 'lax' | 'none' | 'strict' | boolean;
+    /**  The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true. */
+    secure?: boolean | 'auto';
     signed?: boolean;
   }
 

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,4 +1,4 @@
-import cookie from '../plugin';
+import cookie from '..';
 import { expectType } from 'tsd';
 import * as fastifyCookieStar from '..';
 import fastifyCookieCjsImport = require('..');
@@ -57,6 +57,16 @@ server.after((_err) => {
         .clearCookie('foo')
         .send({ hello: 'world' })
     );
+  });
+
+  expectType<(value: string) => string>(server.signCookie)
+  expectType<(value: string) => fastifyCookieStar.UnsignResult>(server.unsignCookie)
+
+  server.get('/', (request, reply) => {
+    expectType<(value: string) => string>(request.signCookie)
+    expectType<(value: string) => string>(reply.signCookie)
+    expectType<(value: string) => fastifyCookieStar.UnsignResult>(request.unsignCookie)
+    expectType<(value: string) => fastifyCookieStar.UnsignResult>(reply.unsignCookie)
   });
 });
 


### PR DESCRIPTION
This PR does not set the sign and unsign decorators, when a secret is not set. 

This makes it possible to feature detect if a secret was purposefully set. If somebody used signing and unsigning with no secret, the person can still provide an empty string as secret.

I assume this is a major.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
