### PR TITLE
feat: option disabling parsing in the onRequest phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const fastify = require('fastify')()
 
 fastify.register(require('@fastify/cookie'), {
   secret: "my-secret", // for cookies signature
-  hook: 'onRequest', // disable cookie autoparsing or set autoparsing on any of the hooks: 'onRequest', 'preParsing', 'preHandler', 'preValidation'. default: onRequest
+  hook: 'onRequest', // set to false to disable cookie autoparsing or set autoparsing on any of the following hooks: 'onRequest', 'preParsing', 'preHandler', 'preValidation'. default: 'onRequest'
   parseOptions: {}  // options for parsing cookies
 })
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ const fastify = require('fastify')()
 
 fastify.register(require('@fastify/cookie'), {
   secret: "my-secret", // for cookies signature
+  addHookOnRequest: false, // disable cookie parsing on the onRequest phase
   parseOptions: {}     // options for parsing cookies
 })
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ const fastify = require('fastify')()
 
 fastify.register(require('@fastify/cookie'), {
   secret: "my-secret", // for cookies signature
-  addHookOnRequest: false, // disable cookie parsing on the onRequest phase
-  parseOptions: {}     // options for parsing cookies
+  hook: 'onRequest', // disable cookie autoparsing or set autoparsing on any of the hooks: 'onRequest', 'preParsing', 'preHandler', 'preValidation'. default: onRequest
+  parseOptions: {}  // options for parsing cookies
 })
 
 fastify.get('/', (req, reply) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/cookie",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Plugin for fastify to add support for cookies",
   "main": "plugin.js",
   "types": "types/plugin.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/cookie",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "description": "Plugin for fastify to add support for cookies",
   "main": "plugin.js",
   "types": "types/plugin.d.ts",

--- a/plugin.js
+++ b/plugin.js
@@ -84,7 +84,7 @@ function getHook (hook = 'onRequest', next) {
 
 function plugin (fastify, options, next) {
   const secret = options.secret
-  const hook = getHook(options.hook, next)
+  const hook = getHook(options.hook)
   if (hook === undefined) {
     return next(new Error('@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, \'onRequest\' , \'preParsing\' , \'preValidation\' or \'preHandler\''))
   }

--- a/plugin.js
+++ b/plugin.js
@@ -72,7 +72,7 @@ function getHook (hook, next) {
     [false]: false
   }
 
-  return hooks[hook] ?? next(new Error('You can set false or use only \'onRequest\' , \'preParsing\' , \'preValidation\' , \'preHandler\' hooks'))
+  return hooks[hook] ?? next(new Error('@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, \'onRequest\' , \'preParsing\' , \'preValidation\' or \'preHandler\''))
 }
 
 function plugin (fastify, options, next) {

--- a/plugin.js
+++ b/plugin.js
@@ -70,7 +70,7 @@ function onReqHandlerWrapper (fastify, hook) {
     }
 }
 
-function getHook (hook = 'onRequest', next) {
+function getHook (hook = 'onRequest') {
   const hooks = {
     onRequest: 'onRequest',
     preParsing: 'preParsing',

--- a/plugin.js
+++ b/plugin.js
@@ -63,6 +63,7 @@ function onReqHandlerWrapper (fastify) {
 
 function plugin (fastify, options, next) {
   const secret = options.secret
+  const addHookOnRequest = options.addHookOnRequest ?? true
   const enableRotation = Array.isArray(secret)
   const algorithm = options.algorithm || 'sha256'
   const signer = typeof secret === 'string' || enableRotation ? new Signer(secret, algorithm) : secret
@@ -86,7 +87,9 @@ function plugin (fastify, options, next) {
   fastify.decorateReply('setCookie', setCookie)
   fastify.decorateReply('clearCookie', clearCookie)
 
-  fastify.addHook('onRequest', onReqHandlerWrapper(fastify))
+  if (addHookOnRequest) {
+    fastify.addHook('onRequest', onReqHandlerWrapper(fastify))
+  }
 
   next()
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -886,3 +886,60 @@ test('result in an error if hook-option is set to an invalid value', (t) => {
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })
+
+test('correct working plugin if hook-option to preParsing', (t) => {
+  t.plan(5)
+  const fastify = Fastify()
+  fastify.register(plugin, { hook: 'preParsing' })
+
+  fastify.addHook('onRequest', async (req) => {
+    t.equal(req.cookies, null)
+  })
+
+  fastify.addHook('preValidation', async (req) => {
+    t.equal(req.cookies.bar, 'bar')
+  })
+
+  fastify.get('/preparsing', (req, reply) => {
+    t.equal(req.cookies.bar, 'bar')
+    reply.send()
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/preparsing',
+    headers: {
+      cookie: 'bar=bar'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+  })
+})
+
+test('if cookies are not set, then the handler creates an empty req.cookies object', (t) => {
+  t.plan(5)
+  const fastify = Fastify()
+  fastify.register(plugin, { hook: 'preParsing' })
+
+  fastify.addHook('onRequest', async (req) => {
+    t.equal(req.cookies, null)
+  })
+
+  fastify.addHook('preValidation', async (req) => {
+    t.ok(req.cookies)
+  })
+
+  fastify.get('/preparsing', (req, reply) => {
+    t.ok(req.cookies)
+    reply.send()
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/preparsing'
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
+  })
+})

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -848,11 +848,10 @@ test('should not decorate fastify, request and reply if no secret was provided',
   })
 })
 
-// addHookOnRequest: false
 test('disable parses incoming cookies', (t) => {
   t.plan(6)
   const fastify = Fastify()
-  fastify.register(plugin, { addHookOnRequest: false })
+  fastify.register(plugin, { hook: false })
 
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
@@ -880,5 +879,27 @@ test('disable parses incoming cookies', (t) => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 200)
+  })
+})
+
+test('error if option is invalid', (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.register(plugin, { hook: true })
+
+  fastify.get('/error', (req, reply) => {
+    console.log('/error')
+    reply.send()
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/error',
+    headers: {
+      cookie: 'bar=bar'
+    }
+  }, (err, res) => {
+    t.equal(err.name, 'Error')
   })
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -848,7 +848,7 @@ test('should not decorate fastify, request and reply if no secret was provided',
   })
 })
 
-test('dont add default @fastify/cookie hook-function to fastify if hook-option to false  ', (t) => {
+test('dont add auto cookie parsing to onRequest-hook if hook-option is set to false', (t) => {
   t.plan(6)
   const fastify = Fastify()
   fastify.register(plugin, { hook: false })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -859,11 +859,6 @@ test('dont add default @fastify/cookie hook-function to fastify if hook-option t
     })
   }
 
-  fastify.addHook('preParsing', (req, reply, payload, done) => {
-    t.equal(req.cookies, null)
-    done()
-  })
-
   fastify.get('/disable', (req, reply) => {
     t.equal(req.cookies, null)
     reply.send()

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -882,23 +882,14 @@ test('dont add default @fastify/cookie hook-function to fastify if hook-option t
   })
 })
 
-test('result in an error if hook-option is set to an invaid value', (t) => {
+test('result in an error if hook-option is set to an invalid value', (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(plugin, { hook: true })
-
-  fastify.get('/error', (req, reply) => {
-    reply.send()
-  })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/error',
-    headers: {
-      cookie: 'bar=bar'
-    }
-  }, (err, res) => {
-    t.equal(err.name, 'Error')
-  })
+  t.rejects(
+    () => fastify.register(plugin, { hook: true }),
+    {},
+    { skip: true },
+    new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
+  )
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -889,7 +889,6 @@ test('result in an error if hook-option is set to an invalid value', (t) => {
   t.rejects(
     () => fastify.register(plugin, { hook: true }),
     {},
-    { skip: true },
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -853,10 +853,9 @@ test('dont add default @fastify/cookie hook-function to fastify if hook-option t
   const fastify = Fastify()
   fastify.register(plugin, { hook: false })
 
-  for (const hook of ['preValidation', 'preHandler']) {
-    fastify.addHook(hook, (req, reply, done) => {
+  for (const hook of ['preValidation', 'preHandler', 'preParsing']) {
+    fastify.addHook(hook, async (req) => {
       t.equal(req.cookies, null)
-      done()
     })
   }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -850,25 +850,25 @@ test('should not decorate fastify, request and reply if no secret was provided',
 
 // addHookOnRequest: false
 test('disable parses incoming cookies', (t) => {
-  t.plan(7)
+  t.plan(6)
   const fastify = Fastify()
   fastify.register(plugin, { addHookOnRequest: false })
 
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
-      t.notOk(req.cookies)
+      t.equal(req.cookies, null)
       done()
     })
   }
 
   fastify.addHook('preParsing', (req, reply, payload, done) => {
-    t.notOk(req.cookies, null)
+    t.equal(req.cookies, null)
     done()
   })
 
   fastify.get('/disable', (req, reply) => {
-    t.notOk(req.cookies, null)
-    reply.send({ hello: 'world' })
+    t.equal(req.cookies, null)
+    reply.send()
   })
 
   fastify.inject({
@@ -880,6 +880,5 @@ test('disable parses incoming cookies', (t) => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
   })
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -889,7 +889,6 @@ test('result in an error if hook-option is set to an invaid value', (t) => {
   fastify.register(plugin, { hook: true })
 
   fastify.get('/error', (req, reply) => {
-    console.log('/error')
     reply.send()
   })
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -848,7 +848,7 @@ test('should not decorate fastify, request and reply if no secret was provided',
   })
 })
 
-test('disable parses incoming cookies', (t) => {
+test('dont add default @fastify/cookie hook-function to fastify if hook-option to false  ', (t) => {
   t.plan(6)
   const fastify = Fastify()
   fastify.register(plugin, { hook: false })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -882,7 +882,7 @@ test('dont add default @fastify/cookie hook-function to fastify if hook-option t
   })
 })
 
-test('error if option is invalid', (t) => {
+test('result in an error if hook-option is set to an invaid value', (t) => {
   t.plan(1)
   const fastify = Fastify()
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -882,7 +882,6 @@ test('result in an error if hook-option is set to an invalid value', (t) => {
 
   t.rejects(
     () => fastify.register(plugin, { hook: true }),
-    {},
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -129,7 +129,7 @@ declare namespace fastifyCookie {
 
   export interface FastifyCookieOptions {
     secret?: string | string[] | Signer;
-    hook?: HookType| false;
+    hook?: HookType | false;
     parseOptions?: fastifyCookie.CookieSerializeOptions;
   }
 

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -125,9 +125,11 @@ declare namespace fastifyCookie {
     signed?: boolean;
   }
 
+  type HookType = 'onRequest' | 'preParsing' | 'preValidation' | 'preHandler'  | 'preSerialization';
+
   export interface FastifyCookieOptions {
     secret?: string | string[] | Signer;
-    addHookOnRequest?: boolean;
+    hook?: HookType| false;
     parseOptions?: fastifyCookie.CookieSerializeOptions;
   }
 

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -127,6 +127,7 @@ declare namespace fastifyCookie {
 
   export interface FastifyCookieOptions {
     secret?: string | string[] | Signer;
+    addHookOnRequest?: boolean;
     parseOptions?: fastifyCookie.CookieSerializeOptions;
   }
 

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,9 +1,10 @@
 import cookie from '..';
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 import * as fastifyCookieStar from '..';
 import fastifyCookieCjsImport = require('..');
 import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed  } from '..';
-import fastify, { FastifyInstance,  FastifyReply, setCookieWrapper } from 'fastify';
+import fastify, { FastifyInstance,  FastifyPluginCallback,  FastifyReply, setCookieWrapper } from 'fastify';
+import { Server } from 'http';
 
 const fastifyCookieCjs = require('..');
 
@@ -214,3 +215,14 @@ new fastifyCookieStar.Signer(['secretStringInArray'])
 const signer = new fastifyCookieStar.Signer(['secretStringInArray'], 'sha256')
 signer.sign('Lorem Ipsum')
 signer.unsign('Lorem Ipsum')
+
+const appWithHook: FastifyInstance = fastify();
+
+appWithHook.register(cookie, { hook: false });
+appWithHook.register(cookie, { hook: 'onRequest' });
+appWithHook.register(cookie, { hook: 'preHandler' });
+appWithHook.register(cookie, { hook: 'preParsing' });
+appWithHook.register(cookie, { hook: 'preSerialization' });
+appWithHook.register(cookie, { hook: 'preValidation' });
+expectError(appWithHook.register(cookie, { hook: true }));
+expectError(appWithHook.register(cookie, { hook: 'false' }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi!

Sometimes you need to receive cookies in the middleware, and then repeated parsing in the onRequest phase will be superfluous. The "addHookOnRequest: false" option can disable adding a hook, leaving all other functionality.

#### Checklist

- [*] run `npm run test` and `npm run benchmark`
- [*] tests and/or benchmarks are included
- [*] documentation is changed or added
- [*] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      

