### PR TITLE
perf: allow-list only needed files for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "url": "https://github.com/fastify/fastify-cookie/issues"
   },
   "homepage": "https://github.com/fastify/fastify-cookie#readme",
+  "files": ["*.js", "types/*.ts"],
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^18.0.0",


### PR DESCRIPTION
In this small patch I add a short allowList to the `package.json` file, to ensure that only essential files are added to the distributed package.

- The package in its compressed form goes down from 13512 bytes to 9295 bytes (around 31% less)
- In its decompressed form, goes from 79.5kB to 40.9kB (around 48% less)

It can be checked by running npm pack and inspecting the generated artifacts.

Signed-off-by: Andres Correa Casablanca <castarco@coderspirit.xyz>

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included **(does not apply)**
- [X] documentation is changed or added **(does not apply)**
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
