### PR TITLE
Fix typo from 'node' to 'none' in CookieSerializeOptions for sameSite attribute

### DIFF
--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -118,7 +118,7 @@ declare namespace fastifyCookie {
     /**  The `Path` attribute. Defaults to `/` (the root path).  */
     path?: string;
     priority?: "low" | "medium" | "high";
-    /** A `boolean` or one of the `SameSite` string attributes. E.g.: `lax`, `node` or `strict`.  */
+    /** A `boolean` or one of the `SameSite` string attributes. E.g.: `lax`, `none` or `strict`.  */
     sameSite?: 'lax' | 'none' | 'strict' | boolean;
     /**  The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true. */
     secure?: boolean | 'auto';


### PR DESCRIPTION
Fixing typo in [fastify-cookie/typesplugin.d.ts](https://github.com/fastify/fastify-cookie/blob/37bd8409c0d99ee9558f7f485edc56b5bcd1d696/types/plugin.d.ts#L121). 
See [Issue 235](https://github.com/fastify/fastify-cookie/issues/235)