### PR TITLE
Check if onSend was ran and keep resetting the map

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -6,7 +6,7 @@ const cookie = require('cookie')
 const { Signer, sign, unsign } = require('./signer')
 
 const kReplySetCookies = Symbol('fastify.reply.setCookies')
-const kReplySetCookiesHookRan = Symbol('fastify.reply.setCookiesOnSendRan')
+const kReplySetCookiesHookRan = Symbol('fastify.reply.setCookiesHookRan')
 
 function fastifyCookieSetCookie (reply, name, value, options) {
   const opts = Object.assign({}, options)

--- a/plugin.js
+++ b/plugin.js
@@ -6,14 +6,9 @@ const cookie = require('cookie')
 const { Signer, sign, unsign } = require('./signer')
 
 const kReplySetCookies = Symbol('fastify.reply.setCookies')
+const kReplySetCookiesHookRan = Symbol('fastify.reply.setCookiesOnSendRan')
 
 function fastifyCookieSetCookie (reply, name, value, options) {
-  let sendHeaders = false
-  if (reply[kReplySetCookies] === null) {
-    sendHeaders = true
-    reply[kReplySetCookies] = new Map()
-  }
-
   const opts = Object.assign({}, options)
 
   if (opts.expires && Number.isInteger(opts.expires)) {
@@ -35,9 +30,9 @@ function fastifyCookieSetCookie (reply, name, value, options) {
 
   reply[kReplySetCookies].set(`${name};${opts.domain};${opts.path || '/'}`, { name, value, opts })
 
-  if (sendHeaders) {
+  if (reply[kReplySetCookiesHookRan]) {
     setCookies(reply)
-    reply[kReplySetCookies] = null
+    reply[kReplySetCookies].clear()
   }
 
   return reply
@@ -61,6 +56,7 @@ function onReqHandlerWrapper (fastify, hook) {
         fastifyReq.cookies = fastify.parseCookie(cookieHeader)
       }
       fastifyRes[kReplySetCookies] = new Map()
+      fastifyRes[kReplySetCookiesHookRan] = false
       done()
     }
     : function fastifyCookieHandler (fastifyReq, fastifyRes, done) {
@@ -70,6 +66,7 @@ function onReqHandlerWrapper (fastify, hook) {
         fastifyReq.cookies = fastify.parseCookie(cookieHeader)
       }
       fastifyRes[kReplySetCookies] = new Map()
+      fastifyRes[kReplySetCookiesHookRan] = false
       done()
     }
 }
@@ -105,9 +102,8 @@ function fastifyCookieOnSendHandler (fastifyReq, fastifyRes, payload, done) {
     setCookies(fastifyRes)
   }
 
-  // Explicitly set the property to null so that we can
-  // check if the header was already set
-  fastifyRes[kReplySetCookies] = null
+  fastifyRes[kReplySetCookies].clear()
+  fastifyRes[kReplySetCookiesHookRan] = true
 
   done()
 }
@@ -149,6 +145,7 @@ function plugin (fastify, options, next) {
 
   fastify.decorateRequest('cookies', null)
   fastify.decorateReply(kReplySetCookies, null)
+  fastify.decorateReply(kReplySetCookiesHookRan, false)
 
   fastify.decorateReply('cookie', setCookie)
   fastify.decorateReply('setCookie', setCookie)

--- a/plugin.js
+++ b/plugin.js
@@ -56,7 +56,6 @@ function onReqHandlerWrapper (fastify, hook) {
         fastifyReq.cookies = fastify.parseCookie(cookieHeader)
       }
       fastifyRes[kReplySetCookies] = new Map()
-      fastifyRes[kReplySetCookiesHookRan] = false
       done()
     }
     : function fastifyCookieHandler (fastifyReq, fastifyRes, done) {
@@ -66,7 +65,6 @@ function onReqHandlerWrapper (fastify, hook) {
         fastifyReq.cookies = fastify.parseCookie(cookieHeader)
       }
       fastifyRes[kReplySetCookies] = new Map()
-      fastifyRes[kReplySetCookiesHookRan] = false
       done()
     }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -13,6 +13,7 @@ function fastifyCookieSetCookie (reply, name, value, options) {
     sendHeaders = true
     reply[kReplySetCookies] = new Map()
   }
+
   const opts = Object.assign({}, options)
 
   if (opts.expires && Number.isInteger(opts.expires)) {
@@ -36,6 +37,7 @@ function fastifyCookieSetCookie (reply, name, value, options) {
 
   if (sendHeaders) {
     setCookies(reply)
+    reply[kReplySetCookies] = null
   }
 
   return reply


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
We have to keep flushing after our onSend hook ran, because we just don't know if setCookie will get called again or that was the last time

Not reassigning the Map is probably less costly though

@Uzlopak @mcollina 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
