### PR TITLE
perf: only call removeHeader when needed

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -32,7 +32,6 @@ function fastifyCookieSetCookie (reply, name, value, options) {
 
   if (reply[kReplySetCookiesHookRan]) {
     setCookies(reply)
-    reply[kReplySetCookies].clear()
   }
 
   return reply
@@ -71,9 +70,10 @@ function onReqHandlerWrapper (fastify, hook) {
 
 function setCookies (reply) {
   let setCookie = reply.getHeader('Set-Cookie')
+  const setCookieIsUndefined = setCookie === undefined
 
   /* istanbul ignore else */
-  if (setCookie === undefined) {
+  if (setCookieIsUndefined) {
     if (reply[kReplySetCookies].size === 1) {
       for (const c of reply[kReplySetCookies].values()) {
         reply.header('Set-Cookie', cookie.serialize(c.name, c.value, c.opts))
@@ -91,14 +91,14 @@ function setCookies (reply) {
     setCookie.push(cookie.serialize(c.name, c.value, c.opts))
   }
 
-  reply.removeHeader('Set-Cookie')
+  if (!setCookieIsUndefined) reply.removeHeader('Set-Cookie')
   reply.header('Set-Cookie', setCookie)
+  reply[kReplySetCookies].clear()
 }
 
 function fastifyCookieOnSendHandler (fastifyReq, fastifyRes, payload, done) {
   if (fastifyRes[kReplySetCookies].size) {
     setCookies(fastifyRes)
-    fastifyRes[kReplySetCookies].clear()
   }
 
   fastifyRes[kReplySetCookiesHookRan] = true

--- a/plugin.js
+++ b/plugin.js
@@ -79,6 +79,8 @@ function setCookies (reply) {
         reply.header('Set-Cookie', cookie.serialize(c.name, c.value, c.opts))
       }
 
+      reply[kReplySetCookies].clear()
+
       return
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
95% of the time, the header will not be defined when cookies are set, so there is no need to call removeHeader unless needed

Also, the setCookies function itself now resets the Map, which makes it easier to reason about what's going on

Median of 5 tests for 5 cookies

Old:
```shell
100 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬────────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max    │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼────────┤
│ Latency │ 1 ms │ 1 ms │ 2 ms  │ 3 ms │ 1.06 ms │ 0.72 ms │ 120 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴────────┘
┌───────────┬───────┬───────┬─────────┬───────┬──────────┬────────┬───────┐
│ Stat      │ 1%    │ 2.5%  │ 50%     │ 97.5% │ Avg      │ Stdev  │ Min   │
├───────────┼───────┼───────┼─────────┼───────┼──────────┼────────┼───────┤
│ Req/Sec   │ 60159 │ 60159 │ 65791   │ 66367 │ 64938.19 │ 1708.4 │ 60153 │
├───────────┼───────┼───────┼─────────┼───────┼──────────┼────────┼───────┤
│ Bytes/Sec │ 19 MB │ 19 MB │ 20.8 MB │ 21 MB │ 20.5 MB  │ 539 kB │ 19 MB │
└───────────┴───────┴───────┴─────────┴───────┴──────────┴────────┴───────┘

Req/Bytes counts sampled once per second.
# of samples: 11

714k requests in 11.01s, 226 MB read
```

New:
```shell
100 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬────────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max    │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼────────┤
│ Latency │ 1 ms │ 1 ms │ 2 ms  │ 2 ms │ 1.05 ms │ 0.66 ms │ 105 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Req/Sec   │ 64575   │ 64575   │ 70783   │ 71359   │ 70160   │ 1838.4 │ 64549   │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Bytes/Sec │ 20.4 MB │ 20.4 MB │ 22.4 MB │ 22.6 MB │ 22.2 MB │ 585 kB │ 20.4 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

772k requests in 11.01s, 244 MB read
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
