### PR TITLE
remove redundant isNaN check and add fast path for empty options

### DIFF
--- a/cookie.js
+++ b/cookie.js
@@ -121,13 +121,13 @@ function parse (str, opt) {
  */
 
 function serialize (name, val, opt) {
-  if (name.length && !fieldContentRegExp.test(name)) {
-    throw new TypeError('argument name is invalid')
-  }
-
   const enc = opt?.encode || encodeURIComponent
   if (typeof enc !== 'function') {
     throw new TypeError('option encode is invalid')
+  }
+
+  if (name.length && !fieldContentRegExp.test(name)) {
+    throw new TypeError('argument name is invalid')
   }
 
   const value = enc(val)

--- a/cookie.js
+++ b/cookie.js
@@ -126,12 +126,12 @@ function serialize (name, val, opt) {
     throw new TypeError('option encode is invalid')
   }
 
-  if (name.length && !fieldContentRegExp.test(name)) {
+  if (name && !fieldContentRegExp.test(name)) {
     throw new TypeError('argument name is invalid')
   }
 
   const value = enc(val)
-  if (value.length && !fieldContentRegExp.test(value)) {
+  if (value && !fieldContentRegExp.test(value)) {
     throw new TypeError('argument val is invalid')
   }
 

--- a/cookie.js
+++ b/cookie.js
@@ -29,14 +29,6 @@
 'use strict'
 
 /**
- * Module exports.
- * @public
- */
-
-exports.parse = parse
-exports.serialize = serialize
-
-/**
  * RegExp to match field-content in RFC 7230 sec 3.2
  *
  * field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]

--- a/cookie.js
+++ b/cookie.js
@@ -121,7 +121,7 @@ function parse (str, opt) {
  */
 
 function serialize (name, val, opt) {
-  if (!fieldContentRegExp.test(name)) {
+  if (name.length && !fieldContentRegExp.test(name)) {
     throw new TypeError('argument name is invalid')
   }
 

--- a/cookie.js
+++ b/cookie.js
@@ -66,13 +66,13 @@ const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/ // eslint-dis
  * @public
  */
 
-function parse (str, options) {
+function parse (str, opt = {}) {
   if (typeof str !== 'string') {
     throw new TypeError('argument str must be a string')
   }
 
   const result = {}
-  const dec = (options && options.decode) || decode
+  const dec = opt.decode || decode
 
   let pos = 0
   let terminatorPos = 0
@@ -82,6 +82,7 @@ function parse (str, options) {
     if (terminatorPos === str.length) {
       break
     }
+
     terminatorPos = str.indexOf(';', pos)
     terminatorPos = (terminatorPos === -1) ? str.length : terminatorPos
     eqIdx = str.indexOf('=', pos)
@@ -104,8 +105,10 @@ function parse (str, options) {
         ? tryDecode(val, dec)
         : val
     }
+
     pos = terminatorPos + 1
   }
+
   return result
 }
 
@@ -125,8 +128,7 @@ function parse (str, options) {
  * @public
  */
 
-function serialize (name, val, options) {
-  const opt = options || {}
+function serialize (name, val, opt = {}) {
   const enc = opt.encode || encode
   if (typeof enc !== 'function') {
     throw new TypeError('option encode is invalid')
@@ -142,13 +144,15 @@ function serialize (name, val, options) {
   }
 
   let str = name + '=' + value
+
   if (opt.maxAge != null) {
-    const maxAge = opt.maxAge - 0
-    if (isNaN(maxAge) || !isFinite(maxAge)) {
+    const maxAge = +opt.maxAge
+
+    if (!isFinite(maxAge)) {
       throw new TypeError('option maxAge is invalid')
     }
 
-    str += '; Max-Age=' + Math.floor(maxAge)
+    str += '; Max-Age=' + Math.trunc(maxAge)
   }
 
   if (opt.domain) {
@@ -193,6 +197,7 @@ function serialize (name, val, options) {
     const sameSite = typeof opt.sameSite === 'string'
       ? opt.sameSite.toLowerCase()
       : opt.sameSite
+
     switch (sameSite) {
       case true:
         str += '; SameSite=Strict'
@@ -221,11 +226,10 @@ function serialize (name, val, options) {
  * @param {function} decode
  * @private
  */
-
 function tryDecode (str, decode) {
   try {
     return decode(str)
-  } catch (e) {
+  } catch {
     return str
   }
 }

--- a/cookie.js
+++ b/cookie.js
@@ -37,14 +37,6 @@ exports.parse = parse
 exports.serialize = serialize
 
 /**
- * Module variables.
- * @private
- */
-
-const decode = decodeURIComponent
-const encode = encodeURIComponent
-
-/**
  * RegExp to match field-content in RFC 7230 sec 3.2
  *
  * field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]
@@ -66,13 +58,13 @@ const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/ // eslint-dis
  * @public
  */
 
-function parse (str, opt = {}) {
+function parse (str, opt) {
   if (typeof str !== 'string') {
     throw new TypeError('argument str must be a string')
   }
 
   const result = {}
-  const dec = opt.decode || decode
+  const dec = opt?.decode || decodeURIComponent
 
   let pos = 0
   let terminatorPos = 0
@@ -101,7 +93,7 @@ function parse (str, opt = {}) {
         ? str.substring(eqIdx + 1, terminatorPos - 1).trim()
         : str.substring(eqIdx, terminatorPos).trim()
 
-      result[key] = (dec !== decode || val.indexOf('%') !== -1)
+      result[key] = (dec !== decodeURIComponent || val.indexOf('%') !== -1)
         ? tryDecode(val, dec)
         : val
     }
@@ -129,7 +121,7 @@ function parse (str, opt = {}) {
  */
 
 function serialize (name, val, opt = {}) {
-  const enc = opt.encode || encode
+  const enc = opt.encode || encodeURIComponent
   if (typeof enc !== 'function') {
     throw new TypeError('option encode is invalid')
   }

--- a/cookie.js
+++ b/cookie.js
@@ -53,7 +53,7 @@ const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/ // eslint-dis
  * The object has the various cookies as keys(names) => values
  *
  * @param {string} str
- * @param {object} opt
+ * @param {object} [opt]
  * @return {object}
  * @public
  */
@@ -115,7 +115,7 @@ function parse (str, opt) {
  *
  * @param {string} name
  * @param {string} val
- * @param {object} [options]
+ * @param {object} [opt]
  * @return {string}
  * @public
  */

--- a/cookie.js
+++ b/cookie.js
@@ -121,7 +121,7 @@ function parse (str, opt) {
  */
 
 function serialize (name, val, opt) {
-  if (name?.length && !fieldContentRegExp.test(name)) {
+  if (!fieldContentRegExp.test(name)) {
     throw new TypeError('argument name is invalid')
   }
 

--- a/cookie.js
+++ b/cookie.js
@@ -121,7 +121,7 @@ function parse (str, opt) {
  */
 
 function serialize (name, val, opt) {
-  if (name.length && !fieldContentRegExp.test(name)) {
+  if (name?.length && !fieldContentRegExp.test(name)) {
     throw new TypeError('argument name is invalid')
   }
 

--- a/cookie.js
+++ b/cookie.js
@@ -37,14 +37,6 @@ exports.parse = parse
 exports.serialize = serialize
 
 /**
- * Module variables.
- * @private
- */
-
-const decode = decodeURIComponent
-const encode = encodeURIComponent
-
-/**
  * RegExp to match field-content in RFC 7230 sec 3.2
  *
  * field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]

--- a/cookie.js
+++ b/cookie.js
@@ -121,7 +121,7 @@ function parse (str, opt) {
  */
 
 function serialize (name, val, opt) {
-  if (name?.length && !fieldContentRegExp.test(name)) {
+  if (name.length && !fieldContentRegExp.test(name)) {
     throw new TypeError('argument name is invalid')
   }
 

--- a/cookie.js
+++ b/cookie.js
@@ -53,7 +53,7 @@ const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/ // eslint-dis
  * The object has the various cookies as keys(names) => values
  *
  * @param {string} str
- * @param {object} [options]
+ * @param {object} opt
  * @return {object}
  * @public
  */
@@ -120,22 +120,24 @@ function parse (str, opt) {
  * @public
  */
 
-function serialize (name, val, opt = {}) {
-  const enc = opt.encode || encodeURIComponent
+function serialize (name, val, opt) {
+  if (name.length && !fieldContentRegExp.test(name)) {
+    throw new TypeError('argument name is invalid')
+  }
+
+  const enc = opt?.encode || encodeURIComponent
   if (typeof enc !== 'function') {
     throw new TypeError('option encode is invalid')
   }
 
-  if (!fieldContentRegExp.test(name)) {
-    throw new TypeError('argument name is invalid')
-  }
-
   const value = enc(val)
-  if (value && !fieldContentRegExp.test(value)) {
+  if (value.length && !fieldContentRegExp.test(value)) {
     throw new TypeError('argument val is invalid')
   }
 
   let str = name + '=' + value
+
+  if (opt == null) return str
 
   if (opt.maxAge != null) {
     const maxAge = +opt.maxAge
@@ -216,6 +218,7 @@ function serialize (name, val, opt = {}) {
  *
  * @param {string} str
  * @param {function} decode
+ * @returns {string}
  * @private
  */
 function tryDecode (str, decode) {


### PR DESCRIPTION
[isFinite already covers NaN](https://github.com/fastify/fastify-cookie/pull/264/files#diff-57263c42de10223876c477ef63af8e65230cc0c5a629637daf6516ad093e3d1eL139)

Also added a fast path for the case where `options` is undefined

Benchmark `benchmark/cookie`

Before:
```bash
Running 10s test @ http://127.0.0.1:5001
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.12 ms │ 20 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬──────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev    │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼──────────┼─────────┤
│ Req/Sec   │ 35,807  │ 35,807  │ 49,311  │ 52,735  │ 47,676.8 │ 5,391.76 │ 35,785  │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼──────────┼─────────┤
│ Bytes/Sec │ 7.77 MB │ 7.77 MB │ 10.7 MB │ 11.4 MB │ 10.3 MB  │ 1.17 MB  │ 7.77 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴──────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 10

477k requests in 10.01s, 103 MB read
```

Now:

```bash
Running 10s test @ http://127.0.0.1:5001
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 0 ms │ 0.01 ms │ 0.09 ms │ 20 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬────────┬────────┬─────────┬─────────┬───────────┬─────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg       │ Stdev   │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼───────────┼─────────┼────────┤
│ Req/Sec   │ 43,327 │ 43,327 │ 49,823  │ 53,279  │ 49,444.37 │ 2,829.3 │ 43,320 │
├───────────┼────────┼────────┼─────────┼─────────┼───────────┼─────────┼────────┤
│ Bytes/Sec │ 9.4 MB │ 9.4 MB │ 10.8 MB │ 11.6 MB │ 10.7 MB   │ 615 kB  │ 9.4 MB │
└───────────┴────────┴────────┴─────────┴─────────┴───────────┴─────────┴────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

544k requests in 11.01s, 118 MB read
```