### PR TITLE
set sameSite: lax by default

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -11,7 +11,7 @@ const kReplySetCookiesHookRan = Symbol('fastify.reply.setCookiesHookRan')
 function fastifyCookieSetCookie (reply, name, value, options) {
   parseCookies(reply.server, reply.request, reply)
 
-  const opts = Object.assign({}, options)
+  const opts = Object.assign({ sameSite: 'lax' }, options)
 
   if (opts.expires && Number.isInteger(opts.expires)) {
     opts.expires = new Date(opts.expires)
@@ -25,7 +25,6 @@ function fastifyCookieSetCookie (reply, name, value, options) {
     if (isConnectionSecure(reply.request)) {
       opts.secure = true
     } else {
-      opts.sameSite = 'lax'
       opts.secure = false
     }
   }
@@ -45,6 +44,7 @@ function fastifyCookieClearCookie (reply, name, options) {
     signed: undefined,
     maxAge: undefined
   })
+
   return fastifyCookieSetCookie(reply, name, '', opts)
 }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -127,8 +127,8 @@ test('should set multiple cookies', (t) => {
     t.equal(cookies[2].name, 'wee')
     t.equal(cookies[2].value, 'woo')
 
-    t.equal(res.headers['set-cookie'][1], 'bar=test; Partitioned')
-    t.equal(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned')
+    t.equal(res.headers['set-cookie'][1], 'bar=test; Partitioned; SameSite=Lax')
+    t.equal(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned; SameSite=Lax')
   })
 })
 
@@ -957,7 +957,7 @@ test('result in an error if hook-option is set to an invalid value', (t) => {
   const fastify = Fastify()
 
   t.rejects(
-    () => fastify.register(plugin, { hook: true }),
+    async () => fastify.register(plugin, { hook: true }),
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })


### PR DESCRIPTION
closes #268

There isn't a connection between `secure` and `sameSite`, so it doesn't make sense to override the user's setting if the connection is insecure

However, having `'lax'` as the default option is useful since even though the absence of sameSite is interpreted as 'lax' by modern browsers, some user agents might not behave this way

Ref: https://web.dev/articles/samesite-cookies-explained#changes_to_the_default_behavior_without_samesite