### PR TITLE
fix: use request.protocol to check for HTTPS

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -22,7 +22,7 @@ function fastifyCookieSetCookie (reply, name, value, options) {
   }
 
   if (opts.secure === 'auto') {
-    if (isConnectionSecure(reply.request)) {
+    if (reply.request.protocol === 'https') {
       opts.secure = true
     } else {
       opts.sameSite = 'lax'
@@ -185,13 +185,6 @@ function getHook (hook = 'onRequest') {
   }
 
   return hooks[hook]
-}
-
-function isConnectionSecure (request) {
-  return (
-    request.raw.socket?.encrypted === true ||
-    request.headers['x-forwarded-proto'] === 'https'
-  )
 }
 
 const fastifyCookie = fp(plugin, {

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -854,7 +854,7 @@ test('create signed cookie manually using signCookie decorator', async (t) => {
 })
 
 test('handle secure:auto of cookieOptions', async (t) => {
-  const fastify = Fastify()
+  const fastify = Fastify({ trustProxy: true })
 
   await fastify.register(plugin)
 


### PR DESCRIPTION
The header shouldn't be read unless `trustProxy` is true.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
