### PR TITLE
Fix problematic type comments

### DIFF
--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -115,21 +115,21 @@ declare namespace fastifyCookie {
     domain?: string;
     /** Specifies a function that will be used to encode a cookie's value. Since value of a cookie has a limited character set (and must be a simple string), this function can be used to encode a value into a string suited for a cookie's value. */
     encode?(val: string): string;
-    /** The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used. */
+    /** The expiration `date` used for the `Expires` attribute. */
     expires?: Date;
-    /** The `boolean` value of the `HttpOnly` attribute. Defaults to true. */
+    /** The `boolean` value of the `HttpOnly` attribute. */
     httpOnly?: boolean;
-    /** A `number` in seconds that specifies the `Expires` attribute by adding the specified seconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used. */
+    /** A `number` in seconds that specifies the `Max-Age` attribute. */
     maxAge?: number;
     /** A `boolean` indicating whether the cookie is tied to the top-level site where it's initially set and cannot be accessed from elsewhere. */
     partitioned?: boolean;
-    /** The `Path` attribute. Defaults to `/` (the root path).  */
+    /** The `Path` attribute. */
     path?: string;
     /** A `boolean` or one of the `SameSite` string attributes. E.g.: `lax`, `none` or `strict`.  */
     sameSite?: 'lax' | 'none' | 'strict' | boolean;
     /** One of the `Priority` string attributes (`low`, `medium` or `high`) specifying a retention priority for HTTP cookies that will be respected by user agents during cookie eviction. */
     priority?: 'low' | 'medium' | 'high';
-    /** The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true. */
+    /** The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true. */
     secure?: boolean;
   }
 

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -117,7 +117,7 @@ declare namespace fastifyCookie {
     encode?(val: string): string;
     /** The expiration `date` used for the `Expires` attribute. */
     expires?: Date;
-    /** The `boolean` value of the `HttpOnly` attribute. */
+    /** Add the `HttpOnly` attribute. Defaults to `false`. */
     httpOnly?: boolean;
     /** A `number` in seconds that specifies the `Max-Age` attribute. */
     maxAge?: number;
@@ -129,11 +129,12 @@ declare namespace fastifyCookie {
     sameSite?: 'lax' | 'none' | 'strict' | boolean;
     /** One of the `Priority` string attributes (`low`, `medium` or `high`) specifying a retention priority for HTTP cookies that will be respected by user agents during cookie eviction. */
     priority?: 'low' | 'medium' | 'high';
-    /** The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true. */
+    /** Add the `Secure` attribute. Defaults to `false`. */
     secure?: boolean;
   }
 
   export interface CookieSerializeOptions extends Omit<SerializeOptions, 'secure'> {
+    /** Add the `Secure` attribute. Value can be set to `"auto"`; in this case the `Secure` attribute will only be added for HTTPS requests. Defaults to `false`. */
     secure?: boolean | 'auto';
     signed?: boolean;
   }


### PR DESCRIPTION
A previous commit introduced some comments that didn't reflect the real implementation which may lead to unsafe assumptions of default behaviors:

https://github.com/fastify/fastify-cookie/commit/04ea01fbede66e409889b26c7e59ffd3468bab92#diff-0647ab7efe94459b8666eed6d1660236e363af58bb3fa7eda85041a316c97bb2R108-R126

This PR fixes that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
