### PR TITLE
fix(types): stricter types for unsigned cookies

### DIFF
--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -155,10 +155,14 @@ declare namespace fastifyCookie {
   export type Unsign = (input: string, secret: string | Buffer, algorithm?: string) => UnsignResult;
   export type SignerFactory = (secrets: string | string[] | Buffer | Buffer[], algorithm?: string) => SignerBase;
 
-  export interface UnsignResult {
-    valid: boolean;
+  export type UnsignResult = {
+    valid: true;
     renew: boolean;
-    value: string | null;
+    value: string;
+  } | {
+    valid: false;
+    renew: false;
+    value: null;
   }
 
   export const signerFactory: SignerFactory;

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -150,11 +150,15 @@ appWithRotationSecret.register(cookie, {
 appWithRotationSecret.after(() => {
   server.get('/', (request, reply) => {
     reply.unsignCookie(request.cookies.test!);
-    const { valid, renew, value } = reply.unsignCookie('test');
+    const unsigned = reply.unsignCookie('test');
 
-    expectType<boolean>(valid);
-    expectType<boolean>(renew);
-    expectType<string | null>(value);
+    expectType<boolean>(unsigned.valid);
+    if (unsigned.valid) {
+      expectType<string>(unsigned.value);
+    } else {
+      expectType<null>(unsigned.value);
+    }
+    expectType<boolean>(unsigned.renew);
 
     reply.send({ hello: 'world' });
   });
@@ -182,11 +186,15 @@ appWithParseOptions.register(cookie, {
 });
 appWithParseOptions.after(() => {
   server.get('/', (request, reply) => {
-    const { valid, renew, value } = reply.unsignCookie(request.cookies.test!);
+    const unsigned = reply.unsignCookie(request.cookies.test!);
 
-    expectType<boolean>(valid);
-    expectType<boolean>(renew);
-    expectType<string | null>(value);
+    expectType<boolean>(unsigned.valid);
+    if (unsigned.valid) {
+      expectType<string>(unsigned.value);
+    } else {
+      expectType<null>(unsigned.value);
+    }
+    expectType<boolean>(unsigned.renew);
   });
 });
 
@@ -204,11 +212,15 @@ appWithCustomSigner.register(cookie, {
 appWithCustomSigner.after(() => {
   server.get('/', (request, reply) => {
     reply.unsignCookie(request.cookies.test!)
-    const { valid, renew, value } = reply.unsignCookie('test')
+    const unsigned = reply.unsignCookie('test')
 
-    expectType<boolean>(valid)
-    expectType<boolean>(renew)
-    expectType<string | null>(value)
+    expectType<boolean>(unsigned.valid);
+    if (unsigned.valid) {
+      expectType<string>(unsigned.value);
+    } else {
+      expectType<null>(unsigned.value);
+    }
+    expectType<boolean>(unsigned.renew);
 
     reply.send({ hello: 'world' })
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR narrows the return type of `unsign` to better reflect the Signer logic. Specifically, that if unsigning fails the `renew` property will be `false` and `value` will be `null`, but if it succeeds `renew` can be `boolean`, but `value` can only be a `string`, never `null`.

This is consistent with the logic in the default Signer, but it does mean that custom Signers have to use the same high-level logic.
