### PR TITLE
chore: move from tap to node:test

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:unit:verbose": "npm run test:unit -- -Rspec"
   },
   "precommit": [
@@ -43,11 +43,11 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "benchmark": "^2.1.4",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "sinon": "^19.0.2",
     "snazzy": "^9.0.0",
     "standard": "^17.1.0",
-    "tap": "^18.6.1",
     "tsd": "^0.31.1"
   },
   "dependencies": {

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -1,13 +1,14 @@
 'use strict'
 
 const { describe, test } = require('node:test')
-const assert = require('node:assert/strict')
 const Fastify = require('fastify')
 const sinon = require('sinon')
 const { sign, unsign } = require('../signer')
 const plugin = require('../')
 
-test('cookies get set correctly', (t) => {
+test('cookies get set correctly', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -17,24 +18,24 @@ test('cookies get set correctly', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-  }).catch(err => {
-    assert.fail(err)
   })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
 })
 
-test('express cookie compatibility', (t) => {
+test('express cookie compatibility', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -44,24 +45,23 @@ test('express cookie compatibility', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/espresso'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
 })
 
-test('should set multiple cookies', (t) => {
+test('should set multiple cookies', async (t) => {
+  t.plan(9)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -73,27 +73,26 @@ test('should set multiple cookies', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 3)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[1].name, 'bar')
-    assert.strictEqual(cookies[1].value, 'test')
-    assert.strictEqual(cookies[2].name, 'wee')
-    assert.strictEqual(cookies[2].value, 'woo')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 3)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[1].name, 'bar')
+  t.assert.strictEqual(cookies[1].value, 'test')
+  t.assert.strictEqual(cookies[2].name, 'wee')
+  t.assert.strictEqual(cookies[2].value, 'woo')
 })
 
-test('should set multiple cookies', (t) => {
+test('should set multiple cookies', async (t) => {
+  t.plan(11)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -110,30 +109,29 @@ test('should set multiple cookies', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 3)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[1].name, 'bar')
-    assert.strictEqual(cookies[1].value, 'test')
-    assert.strictEqual(cookies[2].name, 'wee')
-    assert.strictEqual(cookies[2].value, 'woo')
-
-    assert.strictEqual(res.headers['set-cookie'][1], 'bar=test; Partitioned; SameSite=Lax')
-    assert.strictEqual(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned; SameSite=Lax')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 3)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[1].name, 'bar')
+  t.assert.strictEqual(cookies[1].value, 'test')
+  t.assert.strictEqual(cookies[2].name, 'wee')
+  t.assert.strictEqual(cookies[2].value, 'woo')
+
+  t.assert.strictEqual(res.headers['set-cookie'][1], 'bar=test; Partitioned; SameSite=Lax')
+  t.assert.strictEqual(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned; SameSite=Lax')
 })
 
-test('should set multiple cookies (an array already exists)', (t) => {
+test('should set multiple cookies (an array already exists)', async (t) => {
+  t.plan(9)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -145,28 +143,27 @@ test('should set multiple cookies (an array already exists)', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 3)
-    assert.strictEqual(cookies[0].name, 'bar')
-    assert.strictEqual(cookies[0].value, 'bar')
-    assert.strictEqual(cookies[0].path, undefined)
-
-    assert.strictEqual(cookies[1].name, 'foo')
-    assert.strictEqual(cookies[1].value, 'foo')
-    assert.strictEqual(cookies[2].path, '/path')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 3)
+  t.assert.strictEqual(cookies[0].name, 'bar')
+  t.assert.strictEqual(cookies[0].value, 'bar')
+  t.assert.strictEqual(cookies[0].path, undefined)
+
+  t.assert.strictEqual(cookies[1].name, 'foo')
+  t.assert.strictEqual(cookies[1].value, 'foo')
+  t.assert.strictEqual(cookies[2].path, '/path')
 })
 
-test('cookies get set correctly with millisecond dates', (t) => {
+test('cookies get set correctly with millisecond dates', async (t) => {
+  t.plan(7)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -176,26 +173,25 @@ test('cookies get set correctly with millisecond dates', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-    const expires = new Date(cookies[0].expires)
-    assert.ok(expires < new Date(Date.now() + 5000))
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
+  const expires = new Date(cookies[0].expires)
+  t.assert.ok(expires < new Date(Date.now() + 5000))
 })
 
-test('share options for setCookie and clearCookie', (t) => {
+test('share options for setCookie and clearCookie', async (t) => {
+  t.plan(7)
+
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -212,26 +208,25 @@ test('share options for setCookie and clearCookie', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, '')
-    assert.strictEqual(cookies[0].maxAge, 0)
-
-    assert.ok(new Date(cookies[0].expires) < new Date())
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, '')
+  t.assert.strictEqual(cookies[0].maxAge, 0)
+
+  t.assert.ok(new Date(cookies[0].expires) < new Date())
 })
 
-test('expires should not be overridden in clearCookie', (t) => {
+test('expires should not be overridden in clearCookie', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -248,118 +243,120 @@ test('expires should not be overridden in clearCookie', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, '')
-    const expires = new Date(cookies[0].expires)
-    assert.ok(expires < new Date(Date.now() + 5000))
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, '')
+  const expires = new Date(cookies[0].expires)
+  t.assert.ok(expires < new Date(Date.now() + 5000))
 })
 
-test('parses incoming cookies', (t) => {
+test('parses incoming cookies', async (t) => {
+  t.plan(14)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
   // check that it parses the cookies in the onRequest hook
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
-      assert.ok(req.cookies)
-      assert.ok(req.cookies.bar)
-      assert.strictEqual(req.cookies.bar, 'bar')
+      t.assert.ok(req.cookies)
+      t.assert.ok(req.cookies.bar)
+      t.assert.strictEqual(req.cookies.bar, 'bar')
       done()
     })
   }
 
   fastify.addHook('preParsing', (req, reply, payload, done) => {
-    assert.ok(req.cookies)
-    assert.ok(req.cookies.bar)
-    assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.ok(req.cookies)
+    t.assert.ok(req.cookies.bar)
+    t.assert.strictEqual(req.cookies.bar, 'bar')
     done()
   })
 
   fastify.get('/test2', (req, reply) => {
-    assert.ok(req.cookies)
-    assert.ok(req.cookies.bar)
-    assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.ok(req.cookies)
+    t.assert.ok(req.cookies.bar)
+    t.assert.strictEqual(req.cookies.bar, 'bar')
     reply.send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test2',
     headers: {
       cookie: 'bar=bar'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 })
 
-test('defined and undefined cookies', (t) => {
+test('defined and undefined cookies', async (t) => {
+  t.plan(22)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
   // check that it parses the cookies in the onRequest hook
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
-      assert.ok(req.cookies)
+      t.assert.ok(req.cookies)
 
-      assert.ok(req.cookies.bar)
-      assert.ok(!req.cookies.baz)
+      t.assert.ok(req.cookies.bar)
+      t.assert.ok(!req.cookies.baz)
 
-      assert.strictEqual(req.cookies.bar, 'bar')
-      assert.strictEqual(req.cookies.baz, undefined)
+      t.assert.strictEqual(req.cookies.bar, 'bar')
+      t.assert.strictEqual(req.cookies.baz, undefined)
+      done()
     })
   }
 
   fastify.addHook('preParsing', (req, reply, payload, done) => {
-    assert.ok(req.cookies)
+    t.assert.ok(req.cookies)
 
-    assert.ok(req.cookies.bar)
-    assert.ok(!req.cookies.baz)
+    t.assert.ok(req.cookies.bar)
+    t.assert.ok(!req.cookies.baz)
 
-    assert.strictEqual(req.cookies.bar, 'bar')
-    assert.strictEqual(req.cookies.baz, undefined)
+    t.assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.strictEqual(req.cookies.baz, undefined)
+
+    done()
   })
 
   fastify.get('/test2', (req, reply) => {
-    assert.ok(req.cookies)
+    t.assert.ok(req.cookies)
 
-    assert.ok(req.cookies.bar)
-    assert.ok(!req.cookies.baz)
+    t.assert.ok(req.cookies.bar)
+    t.assert.ok(!req.cookies.baz)
 
-    assert.strictEqual(req.cookies.bar, 'bar')
-    assert.strictEqual(req.cookies.baz, undefined)
+    t.assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.strictEqual(req.cookies.baz, undefined)
 
     reply.send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test2',
     headers: {
       cookie: 'bar=bar'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 })
 
-test('does not modify supplied cookie options object', (t) => {
+test('does not modify supplied cookie options object', async (t) => {
+  t.plan(2)
+
   const expireDate = Date.now() + 1000
   const cookieOptions = {
     path: '/',
@@ -374,21 +371,20 @@ test('does not modify supplied cookie options object', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then(res => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(cookieOptions, {
-      path: '/',
-      expires: expireDate
-    })
-  }).catch(err => {
-    assert.fail(err)
+  })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(cookieOptions, {
+    path: '/',
+    expires: expireDate
   })
 })
 
-test('cookies gets cleared correctly', (t) => {
+test('cookies gets cleared correctly', async (t) => {
+  t.plan(4)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -398,23 +394,22 @@ test('cookies gets cleared correctly', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(new Date(cookies[0].expires) < new Date(), true)
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(new Date(cookies[0].expires) < new Date(), true)
 })
 
 describe('cookies signature', () => {
-  test('unsign', t => {
+  test('unsign', async (t) => {
+    t.plan(5)
+
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -425,23 +420,22 @@ describe('cookies signature', () => {
         .send({ hello: 'world' })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1'
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-      const cookies = res.cookies
-      assert.strictEqual(cookies.length, 1)
-      assert.strictEqual(cookies[0].name, 'foo')
-      assert.deepStrictEqual(unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+    const cookies = res.cookies
+    t.assert.strictEqual(cookies.length, 1)
+    t.assert.strictEqual(cookies[0].name, 'foo')
+    t.assert.deepStrictEqual(unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
   })
 
-  test('key rotation uses first key to sign', t => {
+  test('key rotation uses first key to sign', async (t) => {
+    t.plan(5)
+
     const fastify = Fastify()
     const secret1 = 'secret-1'
     const secret2 = 'secret-2'
@@ -453,23 +447,22 @@ describe('cookies signature', () => {
         .send({ hello: 'world' })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1'
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-      const cookies = res.cookies
-      assert.strictEqual(cookies.length, 1)
-      assert.strictEqual(cookies[0].name, 'foo')
-      assert.deepStrictEqual(unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+    const cookies = res.cookies
+    t.assert.strictEqual(cookies.length, 1)
+    t.assert.strictEqual(cookies[0].name, 'foo')
+    t.assert.deepStrictEqual(unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
   })
 
-  test('unsginCookie via fastify instance', t => {
+  test('unsginCookie via fastify instance', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret = 'bar'
 
@@ -481,21 +474,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
   })
 
-  test('unsignCookie via request decorator', t => {
+  test('unsignCookie via request decorator', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -506,21 +498,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
   })
 
-  test('unsignCookie via reply decorator', t => {
+  test('unsignCookie via reply decorator', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -531,21 +522,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
   })
 
-  test('unsignCookie via request decorator after rotation', t => {
+  test('unsignCookie via request decorator after rotation', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -557,21 +547,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', secret2)}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
   })
 
-  test('unsignCookie via reply decorator after rotation', t => {
+  test('unsignCookie via reply decorator after rotation', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -583,21 +572,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', secret2)}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
   })
 
-  test('unsignCookie via request decorator failure response', t => {
+  test('unsignCookie via request decorator failure response', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -609,21 +597,20 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
   })
 
-  test('unsignCookie reply decorator failure response', t => {
+  test('unsignCookie reply decorator failure response', async (t) => {
+    t.plan(2)
+
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -635,22 +622,21 @@ describe('cookies signature', () => {
       })
     })
 
-    fastify.inject({
+    const res = await fastify.inject({
       method: 'GET',
       url: '/test1',
       headers: {
         cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
-    }).then((res) => {
-      assert.strictEqual(res.statusCode, 200)
-      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
-    }).catch(err => {
-      assert.fail(err)
     })
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
   })
 })
 
-test('custom signer', t => {
+test('custom signer', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   const signStub = sinon.stub().returns('SIGNED-VALUE')
   const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
@@ -663,24 +649,23 @@ test('custom signer', t => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'SIGNED-VALUE')
-    assert.ok(signStub.calledOnceWithExactly('bar'))
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'SIGNED-VALUE')
+  t.assert.ok(signStub.calledOnceWithExactly('bar'))
 })
 
-test('unsignCookie decorator with custom signer', t => {
+test('unsignCookie decorator with custom signer', async (t) => {
+  t.plan(3)
+
   const fastify = Fastify()
   const signStub = sinon.stub().returns('SIGNED-VALUE')
   const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
@@ -693,22 +678,21 @@ test('unsignCookie decorator with custom signer', t => {
     })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1',
     headers: {
       cookie: 'foo=SOME-SIGNED-VALUE'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { unsigned: 'ORIGINAL VALUE' })
-    assert.ok(unsignStub.calledOnceWithExactly('SOME-SIGNED-VALUE'))
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: 'ORIGINAL VALUE' })
+  t.assert.ok(unsignStub.calledOnceWithExactly('SOME-SIGNED-VALUE'))
 })
 
-test('pass options to `cookies.parse`', (t) => {
+test('pass options to `cookies.parse`', async (t) => {
+  t.plan(5)
+
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -717,31 +701,30 @@ test('pass options to `cookies.parse`', (t) => {
   })
 
   fastify.get('/test1', (req, reply) => {
-    assert.ok(req.cookies)
-    assert.ok(req.cookies.foo)
-    assert.strictEqual(req.cookies.foo, 'bartest')
+    t.assert.ok(req.cookies)
+    t.assert.ok(req.cookies.foo)
+    t.assert.strictEqual(req.cookies.foo, 'bartest')
     reply.send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1',
     headers: {
       cookie: 'foo=bar'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
   function decoder (str) {
     return str + 'test'
   }
 })
 
-test('issue 53', (t) => {
+test('issue 53', async (t) => {
+  t.plan(3)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -749,7 +732,7 @@ test('issue 53', (t) => {
   let count = 1
   fastify.get('/foo', (req, reply) => {
     if (count > 1) {
-      assert.notEqual(cookies, req.cookies)
+      t.assert.notEqual(cookies, req.cookies)
       return reply.send('done')
     }
 
@@ -757,41 +740,44 @@ test('issue 53', (t) => {
     cookies = req.cookies
     reply.send('done')
   })
+  {
+    const res = await fastify.inject({ url: '/foo' })
+    t.assert.strictEqual(res.body, 'done')
+  }
 
-  fastify.inject({ url: '/foo' }).then((res) => {
-    assert.strictEqual(res.body, 'done')
-  }).catch(err => {
-    assert.fail(err)
-  })
-
-  fastify.inject({ url: '/foo' }).then((res) => {
-    assert.strictEqual(res.body, 'done')
-  }).catch(err => {
-    assert.fail(err)
-  })
+  {
+    const res = await fastify.inject({ url: '/foo' })
+    t.assert.strictEqual(res.body, 'done')
+  }
 })
 
-test('serialize cookie manually using decorator', (t) => {
+test('serialize cookie manually using decorator', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
-  fastify.ready(() => {
-    assert.ok(fastify.serializeCookie)
-    assert.deepStrictEqual(fastify.serializeCookie('foo', 'bar', {}), 'foo=bar')
-  })
+  await new Promise(resolve => fastify.ready(resolve))
+
+  t.assert.ok(fastify.serializeCookie)
+  t.assert.deepStrictEqual(fastify.serializeCookie('foo', 'bar', {}), 'foo=bar')
 })
 
-test('parse cookie manually using decorator', (t) => {
+test('parse cookie manually using decorator', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
-  fastify.ready(() => {
-    assert.ok(fastify.parseCookie)
-    assert.deepStrictEqual({ ...fastify.parseCookie('foo=bar', {}) }, { foo: 'bar' })
-  })
+  await new Promise(resolve => fastify.ready(resolve))
+
+  t.assert.ok(fastify.parseCookie)
+  t.assert.deepStrictEqual({ ...fastify.parseCookie('foo=bar', {}) }, { foo: 'bar' })
 })
 
-test('cookies set with plugin options parseOptions field', (t) => {
+test('cookies set with plugin options parseOptions field', async (t) => {
+  t.plan(7)
+
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -804,26 +790,25 @@ test('cookies set with plugin options parseOptions field', (t) => {
     reply.setCookie('foo', 'foo').send({ hello: 'world' })
   })
 
-  fastify.inject(
+  const res = await fastify.inject(
     {
       method: 'GET',
       url: '/test'
-    }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+    })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/test')
-    assert.strictEqual(cookies[0].domain, 'example.com')
-  }).catch(err => {
-    assert.fail(err)
-  })
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/test')
+  t.assert.strictEqual(cookies[0].domain, 'example.com')
 })
 
 test('create signed cookie manually using signCookie decorator', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
 
   await fastify.register(plugin, { secret: 'secret' })
@@ -839,11 +824,13 @@ test('create signed cookie manually using signCookie decorator', async (t) => {
     url: '/test1',
     headers: { cookie: `foo=${fastify.signCookie('bar')}` }
   })
-  assert.strictEqual(res.statusCode, 200)
-  assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'bar', renew: false, valid: true } })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'bar', renew: false, valid: true } })
 })
 
 test('handle secure:auto of cookieOptions', async (t) => {
+  t.plan(11)
+
   const fastify = Fastify({ trustProxy: true })
 
   await fastify.register(plugin)
@@ -861,11 +848,11 @@ test('handle secure:auto of cookieOptions', async (t) => {
   })
 
   const cookies = res.cookies
-  assert.strictEqual(cookies.length, 1)
-  assert.strictEqual(cookies[0].name, 'foo')
-  assert.strictEqual(cookies[0].value, 'foo')
-  assert.strictEqual(cookies[0].secure, true)
-  assert.strictEqual(cookies[0].path, '/')
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].secure, true)
+  t.assert.strictEqual(cookies[0].path, '/')
 
   const res2 = await fastify.inject({
     method: 'GET',
@@ -873,27 +860,29 @@ test('handle secure:auto of cookieOptions', async (t) => {
   })
 
   const cookies2 = res2.cookies
-  assert.strictEqual(cookies2.length, 1)
-  assert.strictEqual(cookies2[0].name, 'foo')
-  assert.strictEqual(cookies2[0].value, 'foo')
-  assert.strictEqual(cookies2[0].sameSite, 'Lax')
-  assert.deepStrictEqual(cookies2[0].secure, undefined)
-  assert.strictEqual(cookies2[0].path, '/')
+  t.assert.strictEqual(cookies2.length, 1)
+  t.assert.strictEqual(cookies2[0].name, 'foo')
+  t.assert.strictEqual(cookies2[0].value, 'foo')
+  t.assert.strictEqual(cookies2[0].sameSite, 'Lax')
+  t.assert.deepStrictEqual(cookies2[0].secure, undefined)
+  t.assert.strictEqual(cookies2[0].path, '/')
 })
 
 test('should not decorate fastify, request and reply if no secret was provided', async (t) => {
+  t.plan(8)
+
   const fastify = Fastify()
 
   await fastify.register(plugin)
 
-  assert.ok(!fastify.signCookie)
-  assert.ok(!fastify.unsignCookie)
+  t.assert.ok(!fastify.signCookie)
+  t.assert.ok(!fastify.unsignCookie)
 
   fastify.get('/testDecorators', (req, reply) => {
-    assert.ok(!req.signCookie)
-    assert.ok(!reply.signCookie)
-    assert.ok(!req.unsignCookie)
-    assert.ok(!reply.unsignCookie)
+    t.assert.ok(!req.signCookie)
+    t.assert.ok(!reply.signCookie)
+    t.assert.ok(!req.unsignCookie)
+    t.assert.ok(!reply.unsignCookie)
 
     reply.send({
       unsigned: req.unsignCookie(req.cookies.foo)
@@ -905,109 +894,110 @@ test('should not decorate fastify, request and reply if no secret was provided',
     url: '/testDecorators'
   })
 
-  assert.strictEqual(res.statusCode, 500)
-  assert.deepStrictEqual(JSON.parse(res.body), {
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.deepStrictEqual(JSON.parse(res.body), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'req.unsignCookie is not a function'
   })
 })
 
-test('dont add auto cookie parsing to onRequest-hook if hook-option is set to false', (t) => {
+test('dont add auto cookie parsing to onRequest-hook if hook-option is set to false', async (t) => {
+  t.plan(5)
+
   const fastify = Fastify()
   fastify.register(plugin, { hook: false })
 
   for (const hook of ['preValidation', 'preHandler', 'preParsing']) {
     fastify.addHook(hook, async (req) => {
-      assert.strictEqual(req.cookies, null)
+      t.assert.strictEqual(req.cookies, null)
     })
   }
 
   fastify.get('/disable', (req, reply) => {
-    assert.strictEqual(req.cookies, null)
+    t.assert.strictEqual(req.cookies, null)
     reply.send()
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/disable',
     headers: {
       cookie: 'bar=bar'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
 })
 
 test('result in an error if hook-option is set to an invalid value', async (t) => {
+  t.plan(1)
+
   const fastify = Fastify()
 
-  await assert.rejects(
+  await t.assert.rejects(
     async () => fastify.register(plugin, { hook: true }),
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })
 
-test('correct working plugin if hook-option to preParsing', (t) => {
+test('correct working plugin if hook-option to preParsing', async (t) => {
+  t.plan(4)
+
   const fastify = Fastify()
   fastify.register(plugin, { hook: 'preParsing' })
 
   fastify.addHook('onRequest', async (req) => {
-    assert.strictEqual(req.cookies, null)
+    t.assert.strictEqual(req.cookies, null)
   })
 
   fastify.addHook('preValidation', async (req) => {
-    assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.strictEqual(req.cookies.bar, 'bar')
   })
 
   fastify.get('/preparsing', (req, reply) => {
-    assert.strictEqual(req.cookies.bar, 'bar')
+    t.assert.strictEqual(req.cookies.bar, 'bar')
     reply.send()
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/preparsing',
     headers: {
       cookie: 'bar=bar'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
 })
 
-test('if cookies are not set, then the handler creates an empty req.cookies object', (t) => {
+test('if cookies are not set, then the handler creates an empty req.cookies object', async (t) => {
+  t.plan(4)
+
   const fastify = Fastify()
   fastify.register(plugin, { hook: 'preParsing' })
 
   fastify.addHook('onRequest', async (req) => {
-    assert.strictEqual(req.cookies, null)
+    t.assert.strictEqual(req.cookies, null)
   })
 
   fastify.addHook('preValidation', async (req) => {
-    assert.ok(req.cookies)
+    t.assert.ok(req.cookies)
   })
 
   fastify.get('/preparsing', (req, reply) => {
-    assert.ok(req.cookies)
+    t.assert.ok(req.cookies)
     reply.send()
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/preparsing'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
 })
 
-test('clearCookie should include parseOptions', (t) => {
+test('clearCookie should include parseOptions', async (t) => {
+  t.plan(9)
+
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -1028,29 +1018,28 @@ test('clearCookie should include parseOptions', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, '')
-    assert.strictEqual(cookies[0].maxAge, 0)
-    assert.strictEqual(cookies[0].path, '/test')
-    assert.strictEqual(cookies[0].domain, 'example.com')
-
-    assert.ok(new Date(cookies[0].expires) < new Date())
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, '')
+  t.assert.strictEqual(cookies[0].maxAge, 0)
+  t.assert.strictEqual(cookies[0].path, '/test')
+  t.assert.strictEqual(cookies[0].domain, 'example.com')
+
+  t.assert.ok(new Date(cookies[0].expires) < new Date())
 })
 
-test('should update a cookie value when setCookie is called multiple times', (t) => {
+test('should update a cookie value when setCookie is called multiple times', async (t) => {
+  t.plan(14)
+
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1076,36 +1065,35 @@ test('should update a cookie value when setCookie is called multiple times', (t)
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 3)
-
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, '')
-    assert.strictEqual(cookies[0].path, '/foo')
-
-    assert.strictEqual(cookies[1].name, 'foo')
-    assert.strictEqual(cookies[1].value, sign('foo', secret))
-    assert.strictEqual(cookies[1].maxAge, 36000)
-
-    assert.strictEqual(cookies[2].name, 'foos')
-    assert.strictEqual(cookies[2].value, sign('foosy', secret))
-    assert.strictEqual(cookies[2].path, '/foo')
-    assert.strictEqual(cookies[2].maxAge, 36000)
-
-    assert.ok(new Date(cookies[0].expires) < new Date())
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 3)
+
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, '')
+  t.assert.strictEqual(cookies[0].path, '/foo')
+
+  t.assert.strictEqual(cookies[1].name, 'foo')
+  t.assert.strictEqual(cookies[1].value, sign('foo', secret))
+  t.assert.strictEqual(cookies[1].maxAge, 36000)
+
+  t.assert.strictEqual(cookies[2].name, 'foos')
+  t.assert.strictEqual(cookies[2].value, sign('foosy', secret))
+  t.assert.strictEqual(cookies[2].path, '/foo')
+  t.assert.strictEqual(cookies[2].maxAge, 36000)
+
+  t.assert.ok(new Date(cookies[0].expires) < new Date())
 })
 
-test('should update a cookie value when setCookie is called multiple times (empty header)', (t) => {
+test('should update a cookie value when setCookie is called multiple times (empty header)', async (t) => {
+  t.plan(14)
+
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1132,36 +1120,35 @@ test('should update a cookie value when setCookie is called multiple times (empt
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 3)
-
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, '')
-    assert.strictEqual(cookies[0].path, '/foo')
-
-    assert.strictEqual(cookies[1].name, 'foo')
-    assert.strictEqual(cookies[1].value, sign('foo', secret))
-    assert.strictEqual(cookies[1].maxAge, 36000)
-
-    assert.strictEqual(cookies[2].name, 'foos')
-    assert.strictEqual(cookies[2].value, sign('foosy', secret))
-    assert.strictEqual(cookies[2].path, '/foo')
-    assert.strictEqual(cookies[2].maxAge, 36000)
-
-    assert.ok(new Date(cookies[0].expires) < new Date())
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 3)
+
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, '')
+  t.assert.strictEqual(cookies[0].path, '/foo')
+
+  t.assert.strictEqual(cookies[1].name, 'foo')
+  t.assert.strictEqual(cookies[1].value, sign('foo', secret))
+  t.assert.strictEqual(cookies[1].maxAge, 36000)
+
+  t.assert.strictEqual(cookies[2].name, 'foos')
+  t.assert.strictEqual(cookies[2].value, sign('foosy', secret))
+  t.assert.strictEqual(cookies[2].path, '/foo')
+  t.assert.strictEqual(cookies[2].maxAge, 36000)
+
+  t.assert.ok(new Date(cookies[0].expires) < new Date())
 })
 
-test('should update a cookie value when setCookie is called multiple times (non-empty header)', (t) => {
+test('should update a cookie value when setCookie is called multiple times (non-empty header)', async (t) => {
+  t.plan(14)
+
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1188,36 +1175,35 @@ test('should update a cookie value when setCookie is called multiple times (non-
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 4)
-
-    assert.strictEqual(cookies[1].name, 'foo')
-    assert.strictEqual(cookies[1].value, '')
-    assert.strictEqual(cookies[1].path, '/foo')
-
-    assert.strictEqual(cookies[2].name, 'foo')
-    assert.strictEqual(cookies[2].value, sign('foo', secret))
-    assert.strictEqual(cookies[2].maxAge, 36000)
-
-    assert.strictEqual(cookies[3].name, 'foos')
-    assert.strictEqual(cookies[3].value, sign('foosy', secret))
-    assert.strictEqual(cookies[3].path, '/foo')
-    assert.strictEqual(cookies[3].maxAge, 36000)
-
-    assert.ok(new Date(cookies[1].expires) < new Date())
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 4)
+
+  t.assert.strictEqual(cookies[1].name, 'foo')
+  t.assert.strictEqual(cookies[1].value, '')
+  t.assert.strictEqual(cookies[1].path, '/foo')
+
+  t.assert.strictEqual(cookies[2].name, 'foo')
+  t.assert.strictEqual(cookies[2].value, sign('foo', secret))
+  t.assert.strictEqual(cookies[2].maxAge, 36000)
+
+  t.assert.strictEqual(cookies[3].name, 'foos')
+  t.assert.strictEqual(cookies[3].value, sign('foosy', secret))
+  t.assert.strictEqual(cookies[3].path, '/foo')
+  t.assert.strictEqual(cookies[3].maxAge, 36000)
+
+  t.assert.ok(new Date(cookies[1].expires) < new Date())
 })
 
-test('cookies get set correctly if set inside onSend', (t) => {
+test('cookies get set correctly if set inside onSend', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -1231,24 +1217,23 @@ test('cookies get set correctly if set inside onSend', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
 })
 
-test('cookies get set correctly if set inside multiple onSends', (t) => {
+test('cookies get set correctly if set inside multiple onSends', async (t) => {
+  t.plan(9)
+
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -1266,28 +1251,27 @@ test('cookies get set correctly if set inside multiple onSends', (t) => {
       .send({ hello: 'world' })
   })
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 2)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-
-    assert.strictEqual(cookies[1].name, 'foo')
-    assert.strictEqual(cookies[1].value, 'foos')
-    assert.strictEqual(cookies[1].path, '/')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 2)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
+
+  t.assert.strictEqual(cookies[1].name, 'foo')
+  t.assert.strictEqual(cookies[1].value, 'foos')
+  t.assert.strictEqual(cookies[1].path, '/')
 })
 
-test('cookies get set correctly if set inside onRequest', (t) => {
+test('cookies get set correctly if set inside onRequest', async (t) => {
+  t.plan(6)
+
   const fastify = Fastify()
   fastify.addHook('onRequest', async (req, reply) => {
     reply.setCookie('foo', 'foo', { path: '/' })
@@ -1296,24 +1280,23 @@ test('cookies get set correctly if set inside onRequest', (t) => {
 
   fastify.register(plugin)
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1'
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-
-    const cookies = res.cookies
-    assert.strictEqual(cookies.length, 1)
-    assert.strictEqual(cookies[0].name, 'foo')
-    assert.strictEqual(cookies[0].value, 'foo')
-    assert.strictEqual(cookies[0].path, '/')
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+
+  const cookies = res.cookies
+  t.assert.strictEqual(cookies.length, 1)
+  t.assert.strictEqual(cookies[0].name, 'foo')
+  t.assert.strictEqual(cookies[0].value, 'foo')
+  t.assert.strictEqual(cookies[0].path, '/')
 })
 
-test('do not crash if the onRequest hook is not run', (t) => {
+test('do not crash if the onRequest hook is not run', async (t) => {
+  t.plan(2)
+
   const fastify = Fastify()
   fastify.addHook('onRequest', async (req, reply) => {
     return reply.send({ hello: 'world' })
@@ -1321,16 +1304,13 @@ test('do not crash if the onRequest hook is not run', (t) => {
 
   fastify.register(plugin)
 
-  fastify.inject({
+  const res = await fastify.inject({
     method: 'GET',
     url: '/test1',
     headers: {
       cookie: 'foo=foo'
     }
-  }).then((res) => {
-    assert.strictEqual(res.statusCode, 200)
-    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
-  }).catch(err => {
-    assert.fail(err)
   })
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe, test } = require('node:test')
+const assert = require('node:assert/strict')
 const Fastify = require('fastify')
 const sinon = require('sinon')
 const { sign, unsign } = require('../signer')
 const plugin = require('../')
 
 test('cookies get set correctly', (t) => {
-  t.plan(7)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -20,21 +20,21 @@ test('cookies get set correctly', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('express cookie compatibility', (t) => {
-  t.plan(7)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -47,21 +47,21 @@ test('express cookie compatibility', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/espresso'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should set multiple cookies', (t) => {
-  t.plan(10)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -76,24 +76,24 @@ test('should set multiple cookies', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 3)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[1].name, 'bar')
-    t.equal(cookies[1].value, 'test')
-    t.equal(cookies[2].name, 'wee')
-    t.equal(cookies[2].value, 'woo')
+    assert.strictEqual(cookies.length, 3)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[1].name, 'bar')
+    assert.strictEqual(cookies[1].value, 'test')
+    assert.strictEqual(cookies[2].name, 'wee')
+    assert.strictEqual(cookies[2].value, 'woo')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should set multiple cookies', (t) => {
-  t.plan(12)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -113,27 +113,27 @@ test('should set multiple cookies', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 3)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[1].name, 'bar')
-    t.equal(cookies[1].value, 'test')
-    t.equal(cookies[2].name, 'wee')
-    t.equal(cookies[2].value, 'woo')
+    assert.strictEqual(cookies.length, 3)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[1].name, 'bar')
+    assert.strictEqual(cookies[1].value, 'test')
+    assert.strictEqual(cookies[2].name, 'wee')
+    assert.strictEqual(cookies[2].value, 'woo')
 
-    t.equal(res.headers['set-cookie'][1], 'bar=test; Partitioned; SameSite=Lax')
-    t.equal(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned; SameSite=Lax')
+    assert.strictEqual(res.headers['set-cookie'][1], 'bar=test; Partitioned; SameSite=Lax')
+    assert.strictEqual(res.headers['set-cookie'][2], 'wee=woo; Secure; Partitioned; SameSite=Lax')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should set multiple cookies (an array already exists)', (t) => {
-  t.plan(10)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -148,25 +148,25 @@ test('should set multiple cookies (an array already exists)', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 3)
-    t.equal(cookies[0].name, 'bar')
-    t.equal(cookies[0].value, 'bar')
-    t.equal(cookies[0].path, undefined)
+    assert.strictEqual(cookies.length, 3)
+    assert.strictEqual(cookies[0].name, 'bar')
+    assert.strictEqual(cookies[0].value, 'bar')
+    assert.strictEqual(cookies[0].path, undefined)
 
-    t.equal(cookies[1].name, 'foo')
-    t.equal(cookies[1].value, 'foo')
-    t.equal(cookies[2].path, '/path')
+    assert.strictEqual(cookies[1].name, 'foo')
+    assert.strictEqual(cookies[1].value, 'foo')
+    assert.strictEqual(cookies[2].path, '/path')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('cookies get set correctly with millisecond dates', (t) => {
-  t.plan(8)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -179,23 +179,23 @@ test('cookies get set correctly with millisecond dates', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
     const expires = new Date(cookies[0].expires)
-    t.ok(expires < new Date(Date.now() + 5000))
+    assert.ok(expires < new Date(Date.now() + 5000))
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('share options for setCookie and clearCookie', (t) => {
-  t.plan(8)
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -215,23 +215,23 @@ test('share options for setCookie and clearCookie', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, '')
-    t.equal(cookies[0].maxAge, 0)
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, '')
+    assert.strictEqual(cookies[0].maxAge, 0)
 
-    t.ok(new Date(cookies[0].expires) < new Date())
+    assert.ok(new Date(cookies[0].expires) < new Date())
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('expires should not be overridden in clearCookie', (t) => {
-  t.plan(7)
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -251,46 +251,44 @@ test('expires should not be overridden in clearCookie', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, '')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, '')
     const expires = new Date(cookies[0].expires)
-    t.ok(expires < new Date(Date.now() + 5000))
+    assert.ok(expires < new Date(Date.now() + 5000))
   })
 })
 
 test('parses incoming cookies', (t) => {
-  t.plan(15)
   const fastify = Fastify()
   fastify.register(plugin)
 
   // check that it parses the cookies in the onRequest hook
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
-      t.ok(req.cookies)
-      t.ok(req.cookies.bar)
-      t.equal(req.cookies.bar, 'bar')
+      assert.ok(req.cookies)
+      assert.ok(req.cookies.bar)
+      assert.strictEqual(req.cookies.bar, 'bar')
       done()
     })
   }
 
   fastify.addHook('preParsing', (req, reply, payload, done) => {
-    t.ok(req.cookies)
-    t.ok(req.cookies.bar)
-    t.equal(req.cookies.bar, 'bar')
+    assert.ok(req.cookies)
+    assert.ok(req.cookies.bar)
+    assert.strictEqual(req.cookies.bar, 'bar')
     done()
   })
 
   fastify.get('/test2', (req, reply) => {
-    t.ok(req.cookies)
-    t.ok(req.cookies.bar)
-    t.equal(req.cookies.bar, 'bar')
+    assert.ok(req.cookies)
+    assert.ok(req.cookies.bar)
+    assert.strictEqual(req.cookies.bar, 'bar')
     reply.send({ hello: 'world' })
   })
 
@@ -300,51 +298,49 @@ test('parses incoming cookies', (t) => {
     headers: {
       cookie: 'bar=bar'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('defined and undefined cookies', (t) => {
-  t.plan(23)
   const fastify = Fastify()
   fastify.register(plugin)
 
   // check that it parses the cookies in the onRequest hook
   for (const hook of ['preValidation', 'preHandler']) {
     fastify.addHook(hook, (req, reply, done) => {
-      t.ok(req.cookies)
+      assert.ok(req.cookies)
 
-      t.ok(req.cookies.bar)
-      t.notOk(req.cookies.baz)
+      assert.ok(req.cookies.bar)
+      assert.ok(!req.cookies.baz)
 
-      t.equal(req.cookies.bar, 'bar')
-      t.equal(req.cookies.baz, undefined)
-      done()
+      assert.strictEqual(req.cookies.bar, 'bar')
+      assert.strictEqual(req.cookies.baz, undefined)
     })
   }
 
   fastify.addHook('preParsing', (req, reply, payload, done) => {
-    t.ok(req.cookies)
+    assert.ok(req.cookies)
 
-    t.ok(req.cookies.bar)
-    t.notOk(req.cookies.baz)
+    assert.ok(req.cookies.bar)
+    assert.ok(!req.cookies.baz)
 
-    t.equal(req.cookies.bar, 'bar')
-    t.equal(req.cookies.baz, undefined)
-    done()
+    assert.strictEqual(req.cookies.bar, 'bar')
+    assert.strictEqual(req.cookies.baz, undefined)
   })
 
   fastify.get('/test2', (req, reply) => {
-    t.ok(req.cookies)
+    assert.ok(req.cookies)
 
-    t.ok(req.cookies.bar)
-    t.notOk(req.cookies.baz)
+    assert.ok(req.cookies.bar)
+    assert.ok(!req.cookies.baz)
 
-    t.equal(req.cookies.bar, 'bar')
-    t.equal(req.cookies.baz, undefined)
+    assert.strictEqual(req.cookies.bar, 'bar')
+    assert.strictEqual(req.cookies.baz, undefined)
 
     reply.send({ hello: 'world' })
   })
@@ -355,15 +351,15 @@ test('defined and undefined cookies', (t) => {
     headers: {
       cookie: 'bar=bar'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('does not modify supplied cookie options object', (t) => {
-  t.plan(3)
   const expireDate = Date.now() + 1000
   const cookieOptions = {
     path: '/',
@@ -381,18 +377,18 @@ test('does not modify supplied cookie options object', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.strictSame(cookieOptions, {
+  }).then(res => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(cookieOptions, {
       path: '/',
       expires: expireDate
     })
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('cookies gets cleared correctly', (t) => {
-  t.plan(5)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -405,22 +401,20 @@ test('cookies gets cleared correctly', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(new Date(cookies[0].expires) < new Date(), true)
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(new Date(cookies[0].expires) < new Date(), true)
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
-test('cookies signature', (t) => {
-  t.plan(9)
-
-  t.test('unsign', t => {
-    t.plan(6)
+describe('cookies signature', () => {
+  test('unsign', t => {
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -434,20 +428,20 @@ test('cookies signature', (t) => {
     fastify.inject({
       method: 'GET',
       url: '/test1'
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { hello: 'world' })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
       const cookies = res.cookies
-      t.equal(cookies.length, 1)
-      t.equal(cookies[0].name, 'foo')
-      t.same(unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
+      assert.strictEqual(cookies.length, 1)
+      assert.strictEqual(cookies[0].name, 'foo')
+      assert.deepStrictEqual(unsign(cookies[0].value, secret), { valid: true, renew: false, value: 'foo' })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('key rotation uses first key to sign', t => {
-    t.plan(6)
+  test('key rotation uses first key to sign', t => {
     const fastify = Fastify()
     const secret1 = 'secret-1'
     const secret2 = 'secret-2'
@@ -462,20 +456,20 @@ test('cookies signature', (t) => {
     fastify.inject({
       method: 'GET',
       url: '/test1'
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { hello: 'world' })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
       const cookies = res.cookies
-      t.equal(cookies.length, 1)
-      t.equal(cookies[0].name, 'foo')
-      t.same(unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
+      assert.strictEqual(cookies.length, 1)
+      assert.strictEqual(cookies[0].name, 'foo')
+      assert.deepStrictEqual(unsign(cookies[0].value, secret1), { valid: true, renew: false, value: 'cookieVal' }) // decode using first key
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsginCookie via fastify instance', t => {
-    t.plan(3)
+  test('unsginCookie via fastify instance', t => {
     const fastify = Fastify()
     const secret = 'bar'
 
@@ -493,15 +487,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie via request decorator', t => {
-    t.plan(3)
+  test('unsignCookie via request decorator', t => {
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -518,15 +512,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie via reply decorator', t => {
-    t.plan(3)
+  test('unsignCookie via reply decorator', t => {
     const fastify = Fastify()
     const secret = 'bar'
     fastify.register(plugin, { secret })
@@ -543,15 +537,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', secret)}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: false, valid: true } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie via request decorator after rotation', t => {
-    t.plan(3)
+  test('unsignCookie via request decorator after rotation', t => {
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -569,15 +563,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', secret2)}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie via reply decorator after rotation', t => {
-    t.plan(3)
+  test('unsignCookie via reply decorator after rotation', t => {
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -595,15 +589,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', secret2)}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'foo', renew: true, valid: true } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie via request decorator failure response', t => {
-    t.plan(3)
+  test('unsignCookie via request decorator failure response', t => {
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -621,15 +615,15 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 
-  t.test('unsignCookie reply decorator failure response', t => {
-    t.plan(3)
+  test('unsignCookie reply decorator failure response', t => {
     const fastify = Fastify()
     const secret1 = 'sec-1'
     const secret2 = 'sec-2'
@@ -647,16 +641,16 @@ test('cookies signature', (t) => {
       headers: {
         cookie: `foo=${sign('foo', 'invalid-secret')}`
       }
-    }, (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
+    }).then((res) => {
+      assert.strictEqual(res.statusCode, 200)
+      assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: null, renew: false, valid: false } })
+    }).catch(err => {
+      assert.fail(err)
     })
   })
 })
 
 test('custom signer', t => {
-  t.plan(7)
   const fastify = Fastify()
   const signStub = sinon.stub().returns('SIGNED-VALUE')
   const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
@@ -672,21 +666,21 @@ test('custom signer', t => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'SIGNED-VALUE')
-    t.ok(signStub.calledOnceWithExactly('bar'))
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'SIGNED-VALUE')
+    assert.ok(signStub.calledOnceWithExactly('bar'))
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('unsignCookie decorator with custom signer', t => {
-  t.plan(4)
   const fastify = Fastify()
   const signStub = sinon.stub().returns('SIGNED-VALUE')
   const unsignStub = sinon.stub().returns('ORIGINAL VALUE')
@@ -705,16 +699,16 @@ test('unsignCookie decorator with custom signer', t => {
     headers: {
       cookie: 'foo=SOME-SIGNED-VALUE'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { unsigned: 'ORIGINAL VALUE' })
-    t.ok(unsignStub.calledOnceWithExactly('SOME-SIGNED-VALUE'))
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { unsigned: 'ORIGINAL VALUE' })
+    assert.ok(unsignStub.calledOnceWithExactly('SOME-SIGNED-VALUE'))
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('pass options to `cookies.parse`', (t) => {
-  t.plan(6)
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -723,9 +717,9 @@ test('pass options to `cookies.parse`', (t) => {
   })
 
   fastify.get('/test1', (req, reply) => {
-    t.ok(req.cookies)
-    t.ok(req.cookies.foo)
-    t.equal(req.cookies.foo, 'bartest')
+    assert.ok(req.cookies)
+    assert.ok(req.cookies.foo)
+    assert.strictEqual(req.cookies.foo, 'bartest')
     reply.send({ hello: 'world' })
   })
 
@@ -735,10 +729,11 @@ test('pass options to `cookies.parse`', (t) => {
     headers: {
       cookie: 'foo=bar'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+  }).catch(err => {
+    assert.fail(err)
   })
 
   function decoder (str) {
@@ -747,7 +742,6 @@ test('pass options to `cookies.parse`', (t) => {
 })
 
 test('issue 53', (t) => {
-  t.plan(5)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -755,7 +749,7 @@ test('issue 53', (t) => {
   let count = 1
   fastify.get('/foo', (req, reply) => {
     if (count > 1) {
-      t.not(cookies, req.cookies)
+      assert.notEqual(cookies, req.cookies)
       return reply.send('done')
     }
 
@@ -764,43 +758,40 @@ test('issue 53', (t) => {
     reply.send('done')
   })
 
-  fastify.inject({ url: '/foo' }, (err, response) => {
-    t.error(err)
-    t.equal(response.body, 'done')
+  fastify.inject({ url: '/foo' }).then((res) => {
+    assert.strictEqual(res.body, 'done')
+  }).catch(err => {
+    assert.fail(err)
   })
 
-  fastify.inject({ url: '/foo' }, (err, response) => {
-    t.error(err)
-    t.equal(response.body, 'done')
+  fastify.inject({ url: '/foo' }).then((res) => {
+    assert.strictEqual(res.body, 'done')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('serialize cookie manually using decorator', (t) => {
-  t.plan(2)
   const fastify = Fastify()
   fastify.register(plugin)
 
   fastify.ready(() => {
-    t.ok(fastify.serializeCookie)
-    t.same(fastify.serializeCookie('foo', 'bar', {}), 'foo=bar')
-    t.end()
+    assert.ok(fastify.serializeCookie)
+    assert.deepStrictEqual(fastify.serializeCookie('foo', 'bar', {}), 'foo=bar')
   })
 })
 
 test('parse cookie manually using decorator', (t) => {
-  t.plan(2)
   const fastify = Fastify()
   fastify.register(plugin)
 
   fastify.ready(() => {
-    t.ok(fastify.parseCookie)
-    t.same(fastify.parseCookie('foo=bar', {}), { foo: 'bar' })
-    t.end()
+    assert.ok(fastify.parseCookie)
+    assert.deepStrictEqual({ ...fastify.parseCookie('foo=bar', {}) }, { foo: 'bar' })
   })
 })
 
 test('cookies set with plugin options parseOptions field', (t) => {
-  t.plan(8)
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -817,20 +808,19 @@ test('cookies set with plugin options parseOptions field', (t) => {
     {
       method: 'GET',
       url: '/test'
-    },
-    (err, res) => {
-      t.error(err)
-      t.equal(res.statusCode, 200)
-      t.same(JSON.parse(res.body), { hello: 'world' })
+    }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
-      const cookies = res.cookies
-      t.equal(cookies.length, 1)
-      t.equal(cookies[0].name, 'foo')
-      t.equal(cookies[0].value, 'foo')
-      t.equal(cookies[0].path, '/test')
-      t.equal(cookies[0].domain, 'example.com')
-    }
-  )
+    const cookies = res.cookies
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/test')
+    assert.strictEqual(cookies[0].domain, 'example.com')
+  }).catch(err => {
+    assert.fail(err)
+  })
 })
 
 test('create signed cookie manually using signCookie decorator', async (t) => {
@@ -849,8 +839,8 @@ test('create signed cookie manually using signCookie decorator', async (t) => {
     url: '/test1',
     headers: { cookie: `foo=${fastify.signCookie('bar')}` }
   })
-  t.equal(res.statusCode, 200)
-  t.same(JSON.parse(res.body), { unsigned: { value: 'bar', renew: false, valid: true } })
+  assert.strictEqual(res.statusCode, 200)
+  assert.deepStrictEqual(JSON.parse(res.body), { unsigned: { value: 'bar', renew: false, valid: true } })
 })
 
 test('handle secure:auto of cookieOptions', async (t) => {
@@ -871,11 +861,11 @@ test('handle secure:auto of cookieOptions', async (t) => {
   })
 
   const cookies = res.cookies
-  t.equal(cookies.length, 1)
-  t.equal(cookies[0].name, 'foo')
-  t.equal(cookies[0].value, 'foo')
-  t.equal(cookies[0].secure, true)
-  t.equal(cookies[0].path, '/')
+  assert.strictEqual(cookies.length, 1)
+  assert.strictEqual(cookies[0].name, 'foo')
+  assert.strictEqual(cookies[0].value, 'foo')
+  assert.strictEqual(cookies[0].secure, true)
+  assert.strictEqual(cookies[0].path, '/')
 
   const res2 = await fastify.inject({
     method: 'GET',
@@ -883,28 +873,27 @@ test('handle secure:auto of cookieOptions', async (t) => {
   })
 
   const cookies2 = res2.cookies
-  t.equal(cookies2.length, 1)
-  t.equal(cookies2[0].name, 'foo')
-  t.equal(cookies2[0].value, 'foo')
-  t.equal(cookies2[0].sameSite, 'Lax')
-  t.same(cookies2[0].secure, null)
-  t.equal(cookies2[0].path, '/')
+  assert.strictEqual(cookies2.length, 1)
+  assert.strictEqual(cookies2[0].name, 'foo')
+  assert.strictEqual(cookies2[0].value, 'foo')
+  assert.strictEqual(cookies2[0].sameSite, 'Lax')
+  assert.deepStrictEqual(cookies2[0].secure, undefined)
+  assert.strictEqual(cookies2[0].path, '/')
 })
 
 test('should not decorate fastify, request and reply if no secret was provided', async (t) => {
-  t.plan(8)
   const fastify = Fastify()
 
   await fastify.register(plugin)
 
-  t.notOk(fastify.signCookie)
-  t.notOk(fastify.unsignCookie)
+  assert.ok(!fastify.signCookie)
+  assert.ok(!fastify.unsignCookie)
 
   fastify.get('/testDecorators', (req, reply) => {
-    t.notOk(req.signCookie)
-    t.notOk(reply.signCookie)
-    t.notOk(req.unsignCookie)
-    t.notOk(reply.unsignCookie)
+    assert.ok(!req.signCookie)
+    assert.ok(!reply.signCookie)
+    assert.ok(!req.unsignCookie)
+    assert.ok(!reply.unsignCookie)
 
     reply.send({
       unsigned: req.unsignCookie(req.cookies.foo)
@@ -916,8 +905,8 @@ test('should not decorate fastify, request and reply if no secret was provided',
     url: '/testDecorators'
   })
 
-  t.equal(res.statusCode, 500)
-  t.same(JSON.parse(res.body), {
+  assert.strictEqual(res.statusCode, 500)
+  assert.deepStrictEqual(JSON.parse(res.body), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'req.unsignCookie is not a function'
@@ -925,18 +914,17 @@ test('should not decorate fastify, request and reply if no secret was provided',
 })
 
 test('dont add auto cookie parsing to onRequest-hook if hook-option is set to false', (t) => {
-  t.plan(6)
   const fastify = Fastify()
   fastify.register(plugin, { hook: false })
 
   for (const hook of ['preValidation', 'preHandler', 'preParsing']) {
     fastify.addHook(hook, async (req) => {
-      t.equal(req.cookies, null)
+      assert.strictEqual(req.cookies, null)
     })
   }
 
   fastify.get('/disable', (req, reply) => {
-    t.equal(req.cookies, null)
+    assert.strictEqual(req.cookies, null)
     reply.send()
   })
 
@@ -946,37 +934,36 @@ test('dont add auto cookie parsing to onRequest-hook if hook-option is set to fa
     headers: {
       cookie: 'bar=bar'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
-test('result in an error if hook-option is set to an invalid value', (t) => {
-  t.plan(1)
+test('result in an error if hook-option is set to an invalid value', async (t) => {
   const fastify = Fastify()
 
-  t.rejects(
+  await assert.rejects(
     async () => fastify.register(plugin, { hook: true }),
     new Error("@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'")
   )
 })
 
 test('correct working plugin if hook-option to preParsing', (t) => {
-  t.plan(5)
   const fastify = Fastify()
   fastify.register(plugin, { hook: 'preParsing' })
 
   fastify.addHook('onRequest', async (req) => {
-    t.equal(req.cookies, null)
+    assert.strictEqual(req.cookies, null)
   })
 
   fastify.addHook('preValidation', async (req) => {
-    t.equal(req.cookies.bar, 'bar')
+    assert.strictEqual(req.cookies.bar, 'bar')
   })
 
   fastify.get('/preparsing', (req, reply) => {
-    t.equal(req.cookies.bar, 'bar')
+    assert.strictEqual(req.cookies.bar, 'bar')
     reply.send()
   })
 
@@ -986,41 +973,41 @@ test('correct working plugin if hook-option to preParsing', (t) => {
     headers: {
       cookie: 'bar=bar'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('if cookies are not set, then the handler creates an empty req.cookies object', (t) => {
-  t.plan(5)
   const fastify = Fastify()
   fastify.register(plugin, { hook: 'preParsing' })
 
   fastify.addHook('onRequest', async (req) => {
-    t.equal(req.cookies, null)
+    assert.strictEqual(req.cookies, null)
   })
 
   fastify.addHook('preValidation', async (req) => {
-    t.ok(req.cookies)
+    assert.ok(req.cookies)
   })
 
   fastify.get('/preparsing', (req, reply) => {
-    t.ok(req.cookies)
+    assert.ok(req.cookies)
     reply.send()
   })
 
   fastify.inject({
     method: 'GET',
     url: '/preparsing'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('clearCookie should include parseOptions', (t) => {
-  t.plan(10)
   const fastify = Fastify()
   fastify.register(plugin, {
     parseOptions: {
@@ -1044,26 +1031,26 @@ test('clearCookie should include parseOptions', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
 
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, '')
-    t.equal(cookies[0].maxAge, 0)
-    t.equal(cookies[0].path, '/test')
-    t.equal(cookies[0].domain, 'example.com')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, '')
+    assert.strictEqual(cookies[0].maxAge, 0)
+    assert.strictEqual(cookies[0].path, '/test')
+    assert.strictEqual(cookies[0].domain, 'example.com')
 
-    t.ok(new Date(cookies[0].expires) < new Date())
+    assert.ok(new Date(cookies[0].expires) < new Date())
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should update a cookie value when setCookie is called multiple times', (t) => {
-  t.plan(15)
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1092,33 +1079,33 @@ test('should update a cookie value when setCookie is called multiple times', (t)
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 3)
+    assert.strictEqual(cookies.length, 3)
 
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, '')
-    t.equal(cookies[0].path, '/foo')
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, '')
+    assert.strictEqual(cookies[0].path, '/foo')
 
-    t.equal(cookies[1].name, 'foo')
-    t.equal(cookies[1].value, sign('foo', secret))
-    t.equal(cookies[1].maxAge, 36000)
+    assert.strictEqual(cookies[1].name, 'foo')
+    assert.strictEqual(cookies[1].value, sign('foo', secret))
+    assert.strictEqual(cookies[1].maxAge, 36000)
 
-    t.equal(cookies[2].name, 'foos')
-    t.equal(cookies[2].value, sign('foosy', secret))
-    t.equal(cookies[2].path, '/foo')
-    t.equal(cookies[2].maxAge, 36000)
+    assert.strictEqual(cookies[2].name, 'foos')
+    assert.strictEqual(cookies[2].value, sign('foosy', secret))
+    assert.strictEqual(cookies[2].path, '/foo')
+    assert.strictEqual(cookies[2].maxAge, 36000)
 
-    t.ok(new Date(cookies[0].expires) < new Date())
+    assert.ok(new Date(cookies[0].expires) < new Date())
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should update a cookie value when setCookie is called multiple times (empty header)', (t) => {
-  t.plan(15)
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1148,33 +1135,33 @@ test('should update a cookie value when setCookie is called multiple times (empt
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 3)
+    assert.strictEqual(cookies.length, 3)
 
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, '')
-    t.equal(cookies[0].path, '/foo')
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, '')
+    assert.strictEqual(cookies[0].path, '/foo')
 
-    t.equal(cookies[1].name, 'foo')
-    t.equal(cookies[1].value, sign('foo', secret))
-    t.equal(cookies[1].maxAge, 36000)
+    assert.strictEqual(cookies[1].name, 'foo')
+    assert.strictEqual(cookies[1].value, sign('foo', secret))
+    assert.strictEqual(cookies[1].maxAge, 36000)
 
-    t.equal(cookies[2].name, 'foos')
-    t.equal(cookies[2].value, sign('foosy', secret))
-    t.equal(cookies[2].path, '/foo')
-    t.equal(cookies[2].maxAge, 36000)
+    assert.strictEqual(cookies[2].name, 'foos')
+    assert.strictEqual(cookies[2].value, sign('foosy', secret))
+    assert.strictEqual(cookies[2].path, '/foo')
+    assert.strictEqual(cookies[2].maxAge, 36000)
 
-    t.ok(new Date(cookies[0].expires) < new Date())
+    assert.ok(new Date(cookies[0].expires) < new Date())
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('should update a cookie value when setCookie is called multiple times (non-empty header)', (t) => {
-  t.plan(15)
   const fastify = Fastify()
   const secret = 'testsecret'
   fastify.register(plugin, { secret })
@@ -1204,33 +1191,33 @@ test('should update a cookie value when setCookie is called multiple times (non-
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 4)
+    assert.strictEqual(cookies.length, 4)
 
-    t.equal(cookies[1].name, 'foo')
-    t.equal(cookies[1].value, '')
-    t.equal(cookies[1].path, '/foo')
+    assert.strictEqual(cookies[1].name, 'foo')
+    assert.strictEqual(cookies[1].value, '')
+    assert.strictEqual(cookies[1].path, '/foo')
 
-    t.equal(cookies[2].name, 'foo')
-    t.equal(cookies[2].value, sign('foo', secret))
-    t.equal(cookies[2].maxAge, 36000)
+    assert.strictEqual(cookies[2].name, 'foo')
+    assert.strictEqual(cookies[2].value, sign('foo', secret))
+    assert.strictEqual(cookies[2].maxAge, 36000)
 
-    t.equal(cookies[3].name, 'foos')
-    t.equal(cookies[3].value, sign('foosy', secret))
-    t.equal(cookies[3].path, '/foo')
-    t.equal(cookies[3].maxAge, 36000)
+    assert.strictEqual(cookies[3].name, 'foos')
+    assert.strictEqual(cookies[3].value, sign('foosy', secret))
+    assert.strictEqual(cookies[3].path, '/foo')
+    assert.strictEqual(cookies[3].maxAge, 36000)
 
-    t.ok(new Date(cookies[1].expires) < new Date())
+    assert.ok(new Date(cookies[1].expires) < new Date())
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('cookies get set correctly if set inside onSend', (t) => {
-  t.plan(7)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -1247,21 +1234,21 @@ test('cookies get set correctly if set inside onSend', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('cookies get set correctly if set inside multiple onSends', (t) => {
-  t.plan(10)
   const fastify = Fastify()
   fastify.register(plugin)
 
@@ -1282,25 +1269,25 @@ test('cookies get set correctly if set inside multiple onSends', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 2)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 2)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
 
-    t.equal(cookies[1].name, 'foo')
-    t.equal(cookies[1].value, 'foos')
-    t.equal(cookies[1].path, '/')
+    assert.strictEqual(cookies[1].name, 'foo')
+    assert.strictEqual(cookies[1].value, 'foos')
+    assert.strictEqual(cookies[1].path, '/')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('cookies get set correctly if set inside onRequest', (t) => {
-  t.plan(7)
   const fastify = Fastify()
   fastify.addHook('onRequest', async (req, reply) => {
     reply.setCookie('foo', 'foo', { path: '/' })
@@ -1312,21 +1299,21 @@ test('cookies get set correctly if set inside onRequest', (t) => {
   fastify.inject({
     method: 'GET',
     url: '/test1'
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
 
     const cookies = res.cookies
-    t.equal(cookies.length, 1)
-    t.equal(cookies[0].name, 'foo')
-    t.equal(cookies[0].value, 'foo')
-    t.equal(cookies[0].path, '/')
+    assert.strictEqual(cookies.length, 1)
+    assert.strictEqual(cookies[0].name, 'foo')
+    assert.strictEqual(cookies[0].value, 'foo')
+    assert.strictEqual(cookies[0].path, '/')
+  }).catch(err => {
+    assert.fail(err)
   })
 })
 
 test('do not crash if the onRequest hook is not run', (t) => {
-  t.plan(3)
   const fastify = Fastify()
   fastify.addHook('onRequest', async (req, reply) => {
     return reply.send({ hello: 'world' })
@@ -1340,9 +1327,10 @@ test('do not crash if the onRequest hook is not run', (t) => {
     headers: {
       cookie: 'foo=foo'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 200)
-    t.same(JSON.parse(res.body), { hello: 'world' })
+  }).then((res) => {
+    assert.strictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(JSON.parse(res.body), { hello: 'world' })
+  }).catch(err => {
+    assert.fail(err)
   })
 })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -1,138 +1,109 @@
 'use strict'
 
-const { test } = require('tap')
+const { beforeEach, describe, test } = require('node:test')
+const assert = require('node:assert/strict')
 const sinon = require('sinon')
 const crypto = require('node:crypto')
+
 const { Signer, sign, unsign } = require('../signer')
 
-test('default', t => {
-  t.plan(5)
-
+describe('default', () => {
   const secret = 'my-secret'
   const signer = Signer(secret)
 
-  t.test('signer.sign should throw if there is no value provided', (t) => {
-    t.plan(1)
-
-    t.throws(() => signer.sign(undefined), 'Cookie value must be provided as a string.')
+  test('signer.sign should throw if there is no value provided', () => {
+    assert.throws(() => signer.sign(undefined), err => err.message === 'Cookie value must be provided as a string.')
   })
 
-  t.test('signer.sign', (t) => {
-    t.plan(2)
-
+  test('sign', () => {
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, sign(input, secret))
-    t.throws(() => sign(undefined), 'Cookie value must be provided as a string.')
+    assert.strictEqual(result, sign(input, secret))
+    assert.strictEqual(result, sign(input, [secret]))
+    assert.strictEqual(result, sign(input, Buffer.from(secret)))
+    assert.strictEqual(result, sign(input, [Buffer.from(secret)]))
+
+    assert.throws(() => sign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
   })
 
-  t.test('sign', (t) => {
-    t.plan(5)
-
-    const input = 'some-value'
-    const result = signer.sign(input)
-
-    t.equal(result, sign(input, secret))
-    t.equal(result, sign(input, [secret]))
-    t.equal(result, sign(input, Buffer.from(secret)))
-    t.equal(result, sign(input, [Buffer.from(secret)]))
-
-    t.throws(() => sign(undefined), 'Cookie value must be provided as a string.')
-  })
-
-  t.test('signer.unsign', (t) => {
-    t.plan(4)
-
+  test('signer.unsign', () => {
     const input = signer.sign('some-value', secret)
     const result = signer.unsign(input)
 
-    t.equal(result.valid, true)
-    t.equal(result.renew, false)
-    t.equal(result.value, 'some-value')
-    t.throws(() => signer.unsign(undefined), 'Signed cookie string must be provided.')
+    assert.strictEqual(result.valid, true)
+    assert.strictEqual(result.renew, false)
+    assert.strictEqual(result.value, 'some-value')
+    assert.throws(() => signer.unsign(undefined), err => err.message === 'Signed cookie string must be provided.')
   })
 
-  t.test('unsign', (t) => {
-    t.plan(6)
-
+  test('unsign', () => {
     const input = sign('some-value', secret)
     const result = unsign(input, secret)
 
-    t.equal(result.valid, true)
-    t.equal(result.renew, false)
-    t.equal(result.value, 'some-value')
-    t.same(result, unsign(input, [secret]))
-    t.throws(() => unsign(undefined), 'Secret key must be a string or Buffer.')
-    t.throws(() => unsign(undefined, secret), 'Signed cookie string must be provided.')
+    assert.strictEqual(result.valid, true)
+    assert.strictEqual(result.renew, false)
+    assert.strictEqual(result.value, 'some-value')
+    assert.deepStrictEqual(result, unsign(input, [secret]))
+    assert.throws(() => unsign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
+    assert.throws(() => unsign(undefined, secret), err => err.message === 'Signed cookie string must be provided.')
   })
 })
 
-test('key rotation', (t) => {
-  t.plan(3)
+describe('key rotation', () => {
   const secret1 = 'my-secret-1'
   const secret2 = 'my-secret-2'
   const secret3 = 'my-secret-3'
   const signer = Signer([secret1, secret2, secret3])
   const signSpy = sinon.spy(crypto, 'createHmac')
 
-  t.beforeEach(() => {
+  beforeEach(() => {
     signSpy.resetHistory()
   })
 
-  t.test('signer.sign always signs using first key', (t) => {
-    t.plan(1)
-
+  test('signer.sign always signs using first key', () => {
     const input = 'some-value'
     const result = signer.sign(input)
 
-    t.equal(result, sign(input, secret1))
+    assert.strictEqual(result, sign(input, secret1))
   })
 
-  t.test('signer.unsign tries to decode using all keys till it finds', (t) => {
-    t.plan(4)
-
+  test('signer.unsign tries to decode using all keys till it finds', () => {
     const input = sign('some-value', secret2)
     signSpy.resetHistory()
     const result = signer.unsign(input)
 
-    t.equal(result.valid, true)
-    t.equal(result.renew, true)
-    t.equal(result.value, 'some-value')
-    t.equal(signSpy.callCount, 2) // should have returned early when the right key was found
+    assert.strictEqual(result.valid, true)
+    assert.strictEqual(result.renew, true)
+    assert.strictEqual(result.value, 'some-value')
+    assert.strictEqual(signSpy.callCount, 2) // should have returned early when the right key was found
   })
 
-  t.test('signer.unsign failure response', (t) => {
-    t.plan(4)
-
+  test('signer.unsign failure response', () => {
     const input = sign('some-value', 'invalid-secret')
     signSpy.resetHistory()
     const result = signer.unsign(input)
 
-    t.equal(result.valid, false)
-    t.equal(result.renew, false)
-    t.equal(result.value, null)
-    t.equal(signSpy.callCount, 3) // should have tried all 3
+    assert.strictEqual(result.valid, false)
+    assert.strictEqual(result.renew, false)
+    assert.strictEqual(result.value, null)
+    assert.strictEqual(signSpy.callCount, 3) // should have tried all 3
   })
 })
 
-test('Signer', t => {
-  t.plan(2)
-
-  t.test('Signer needs a string or Buffer as secret', (t) => {
-    t.plan(6)
-    t.throws(() => Signer(1), 'Secret key must be a string or Buffer.')
-    t.throws(() => Signer(undefined), 'Secret key must be a string or Buffer.')
-    t.doesNotThrow(() => Signer('secret'))
-    t.doesNotThrow(() => Signer(['secret']))
-    t.doesNotThrow(() => Signer(Buffer.from('deadbeef76543210', 'hex')))
-    t.doesNotThrow(() => Signer([Buffer.from('deadbeef76543210', 'hex')]))
+describe('Signer', () => {
+  test('Signer needs a string or Buffer as secret', () => {
+    assert.throws(() => Signer(1), err => err.message === 'Secret key must be a string or Buffer.')
+    assert.throws(() => Signer(undefined), err => err.message === 'Secret key must be a string or Buffer.')
+    assert.doesNotThrow(() => Signer('secret'))
+    assert.doesNotThrow(() => Signer(['secret']))
+    assert.doesNotThrow(() => Signer(Buffer.from('deadbeef76543210', 'hex')))
+    assert.doesNotThrow(() => Signer([Buffer.from('deadbeef76543210', 'hex')]))
   })
 
-  t.test('Signer handles algorithm properly', (t) => {
-    t.plan(3)
-    t.throws(() => Signer('secret', 'invalid'), 'Algorithm invalid not supported.')
-    t.doesNotThrow(() => Signer('secret', 'sha512'))
-    t.doesNotThrow(() => Signer('secret', 'sha256'))
+  test('Signer handles algorithm properly', () => {
+    assert.throws(() => Signer('secret', 'invalid'), err => err.message === 'Algorithm invalid not supported.')
+    assert.doesNotThrow(() => Signer('secret', 'sha512'))
+    assert.doesNotThrow(() => Signer('secret', 'sha256'))
   })
 })

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { beforeEach, describe, test } = require('node:test')
-const assert = require('node:assert/strict')
 const sinon = require('sinon')
 const crypto = require('node:crypto')
 
@@ -11,42 +10,49 @@ describe('default', () => {
   const secret = 'my-secret'
   const signer = Signer(secret)
 
-  test('signer.sign should throw if there is no value provided', () => {
-    assert.throws(() => signer.sign(undefined), err => err.message === 'Cookie value must be provided as a string.')
+  test('signer.sign should throw if there is no value provided', (t) => {
+    t.plan(1)
+    t.assert.throws(() => signer.sign(undefined), err => err.message === 'Cookie value must be provided as a string.')
   })
 
-  test('sign', () => {
+  test('sign', (t) => {
+    t.plan(5)
+
     const input = 'some-value'
     const result = signer.sign(input)
 
-    assert.strictEqual(result, sign(input, secret))
-    assert.strictEqual(result, sign(input, [secret]))
-    assert.strictEqual(result, sign(input, Buffer.from(secret)))
-    assert.strictEqual(result, sign(input, [Buffer.from(secret)]))
+    t.assert.strictEqual(result, sign(input, secret))
+    t.assert.strictEqual(result, sign(input, [secret]))
+    t.assert.strictEqual(result, sign(input, Buffer.from(secret)))
+    t.assert.strictEqual(result, sign(input, [Buffer.from(secret)]))
 
-    assert.throws(() => sign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
+    t.assert.throws(() => sign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
   })
 
-  test('signer.unsign', () => {
+  test('signer.unsign', (t) => {
+    t.plan(4)
+
     const input = signer.sign('some-value', secret)
     const result = signer.unsign(input)
 
-    assert.strictEqual(result.valid, true)
-    assert.strictEqual(result.renew, false)
-    assert.strictEqual(result.value, 'some-value')
-    assert.throws(() => signer.unsign(undefined), err => err.message === 'Signed cookie string must be provided.')
+    t.assert.strictEqual(result.valid, true)
+    t.assert.strictEqual(result.renew, false)
+    t.assert.strictEqual(result.value, 'some-value')
+    t.assert.throws(() => signer.unsign(undefined), err => err.message === 'Signed cookie string must be provided.')
   })
 
-  test('unsign', () => {
+  test('unsign', (t) => {
+    t.plan(6)
+
     const input = sign('some-value', secret)
     const result = unsign(input, secret)
 
-    assert.strictEqual(result.valid, true)
-    assert.strictEqual(result.renew, false)
-    assert.strictEqual(result.value, 'some-value')
-    assert.deepStrictEqual(result, unsign(input, [secret]))
-    assert.throws(() => unsign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
-    assert.throws(() => unsign(undefined, secret), err => err.message === 'Signed cookie string must be provided.')
+    t.assert.strictEqual(result.valid, true)
+    t.assert.strictEqual(result.renew, false)
+    t.assert.strictEqual(result.value, 'some-value')
+    t.assert.deepStrictEqual(result, unsign(input, [secret]))
+    t.assert.throws(() => unsign(undefined), err => err.message === 'Secret key must be a string or Buffer.')
+    t.assert.throws(() => unsign(undefined, secret), err => err.message === 'Signed cookie string must be provided.')
   })
 })
 
@@ -61,49 +67,59 @@ describe('key rotation', () => {
     signSpy.resetHistory()
   })
 
-  test('signer.sign always signs using first key', () => {
+  test('signer.sign always signs using first key', (t) => {
+    t.plan(1)
+
     const input = 'some-value'
     const result = signer.sign(input)
 
-    assert.strictEqual(result, sign(input, secret1))
+    t.assert.strictEqual(result, sign(input, secret1))
   })
 
-  test('signer.unsign tries to decode using all keys till it finds', () => {
+  test('signer.unsign tries to decode using all keys till it finds', (t) => {
+    t.plan(4)
+
     const input = sign('some-value', secret2)
     signSpy.resetHistory()
     const result = signer.unsign(input)
 
-    assert.strictEqual(result.valid, true)
-    assert.strictEqual(result.renew, true)
-    assert.strictEqual(result.value, 'some-value')
-    assert.strictEqual(signSpy.callCount, 2) // should have returned early when the right key was found
+    t.assert.strictEqual(result.valid, true)
+    t.assert.strictEqual(result.renew, true)
+    t.assert.strictEqual(result.value, 'some-value')
+    t.assert.strictEqual(signSpy.callCount, 2) // should have returned early when the right key was found
   })
 
-  test('signer.unsign failure response', () => {
+  test('signer.unsign failure response', (t) => {
+    t.plan(4)
+
     const input = sign('some-value', 'invalid-secret')
     signSpy.resetHistory()
     const result = signer.unsign(input)
 
-    assert.strictEqual(result.valid, false)
-    assert.strictEqual(result.renew, false)
-    assert.strictEqual(result.value, null)
-    assert.strictEqual(signSpy.callCount, 3) // should have tried all 3
+    t.assert.strictEqual(result.valid, false)
+    t.assert.strictEqual(result.renew, false)
+    t.assert.strictEqual(result.value, null)
+    t.assert.strictEqual(signSpy.callCount, 3) // should have tried all 3
   })
 })
 
 describe('Signer', () => {
-  test('Signer needs a string or Buffer as secret', () => {
-    assert.throws(() => Signer(1), err => err.message === 'Secret key must be a string or Buffer.')
-    assert.throws(() => Signer(undefined), err => err.message === 'Secret key must be a string or Buffer.')
-    assert.doesNotThrow(() => Signer('secret'))
-    assert.doesNotThrow(() => Signer(['secret']))
-    assert.doesNotThrow(() => Signer(Buffer.from('deadbeef76543210', 'hex')))
-    assert.doesNotThrow(() => Signer([Buffer.from('deadbeef76543210', 'hex')]))
+  test('Signer needs a string or Buffer as secret', (t) => {
+    t.plan(6)
+
+    t.assert.throws(() => Signer(1), err => err.message === 'Secret key must be a string or Buffer.')
+    t.assert.throws(() => Signer(undefined), err => err.message === 'Secret key must be a string or Buffer.')
+    t.assert.doesNotThrow(() => Signer('secret'))
+    t.assert.doesNotThrow(() => Signer(['secret']))
+    t.assert.doesNotThrow(() => Signer(Buffer.from('deadbeef76543210', 'hex')))
+    t.assert.doesNotThrow(() => Signer([Buffer.from('deadbeef76543210', 'hex')]))
   })
 
-  test('Signer handles algorithm properly', () => {
-    assert.throws(() => Signer('secret', 'invalid'), err => err.message === 'Algorithm invalid not supported.')
-    assert.doesNotThrow(() => Signer('secret', 'sha512'))
-    assert.doesNotThrow(() => Signer('secret', 'sha256'))
+  test('Signer handles algorithm properly', (t) => {
+    t.plan(3)
+
+    t.assert.throws(() => Signer('secret', 'invalid'), err => err.message === 'Algorithm invalid not supported.')
+    t.assert.doesNotThrow(() => Signer('secret', 'sha512'))
+    t.assert.doesNotThrow(() => Signer('secret', 'sha256'))
   })
 })


### PR DESCRIPTION
These changes are related to the issue https://github.com/fastify/fastify/issues/5555
Changed signer.test.js and cookie.test.js to use node:test instead of tap.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
