### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^22.0.0",
     "benchmark": "^2.1.4",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "sinon": "^19.0.2",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.