### PR TITLE
types: merge duplicate `FastifyCookieOptions` interface exports

### DIFF
--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -173,6 +173,7 @@ declare namespace fastifyCookie {
   }
 
   export const fastifyCookie: FastifyCookie
+
   export interface FastifyCookieOptions {
     secret?: string | string[] | Buffer | Buffer[] | Signer | SignerBase;
     algorithm?: string;

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -145,12 +145,6 @@ declare namespace fastifyCookie {
 
   type HookType = 'onRequest' | 'preParsing' | 'preValidation' | 'preHandler' | 'preSerialization'
 
-  export interface FastifyCookieOptions {
-    secret?: string | string[] | Buffer | Buffer[] | Signer;
-    hook?: HookType | false;
-    parseOptions?: fastifyCookie.CookieSerializeOptions;
-  }
-
   export type Sign = (value: string, secret: string | Buffer, algorithm?: string) => string
   export type Unsign = (input: string, secret: string | Buffer, algorithm?: string) => UnsignResult
   export type SignerFactory = (secrets: string | string[] | Buffer | Buffer[], algorithm?: string) => SignerBase
@@ -179,10 +173,10 @@ declare namespace fastifyCookie {
   }
 
   export const fastifyCookie: FastifyCookie
-
   export interface FastifyCookieOptions {
-    secret?: string | string[] | Buffer | Buffer[] | SignerBase;
+    secret?: string | string[] | Buffer | Buffer[] | Signer | SignerBase;
     algorithm?: string;
+    hook?: HookType | false;
     parseOptions?: CookieSerializeOptions;
   }
 

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,15 +1,14 @@
-import cookie from '..'
 import { expectError, expectType } from 'tsd'
 import * as fastifyCookieStar from '..'
 import fastifyCookieCjsImport = require('..')
-import fastifyCookieDefault, { fastifyCookie as fastifyCookieNamed, Signer } from '..'
+import cookie, { fastifyCookie as fastifyCookieNamed, Signer } from '..'
 import fastify, { FastifyInstance, FastifyReply, setCookieWrapper } from 'fastify'
 
 const fastifyCookieCjs = require('..')
 
 const app: FastifyInstance = fastify()
 app.register(fastifyCookieNamed)
-app.register(fastifyCookieDefault)
+app.register(cookie)
 app.register(fastifyCookieCjs)
 app.register(fastifyCookieCjsImport.default)
 app.register(fastifyCookieCjsImport.fastifyCookie)
@@ -17,7 +16,7 @@ app.register(fastifyCookieStar.default)
 app.register(fastifyCookieStar.fastifyCookie)
 
 expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieNamed)
-expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieDefault)
+expectType<fastifyCookieStar.FastifyCookie>(cookie)
 expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.default)
 expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieCjsImport.fastifyCookie)
 expectType<fastifyCookieStar.FastifyCookie>(fastifyCookieStar.default)
@@ -26,9 +25,9 @@ expectType<fastifyCookieStar.FastifyCookie>(
 )
 expectType<any>(fastifyCookieCjs)
 
-expectType<fastifyCookieStar.Sign>(fastifyCookieDefault.sign)
-expectType<fastifyCookieStar.Unsign>(fastifyCookieDefault.unsign)
-expectType<fastifyCookieStar.SignerFactory >(fastifyCookieDefault.signerFactory)
+expectType<fastifyCookieStar.Sign>(cookie.sign)
+expectType<fastifyCookieStar.Unsign>(cookie.unsign)
+expectType<fastifyCookieStar.SignerFactory >(cookie.signerFactory)
 
 expectType<fastifyCookieStar.Sign>(fastifyCookieNamed.sign)
 expectType<fastifyCookieStar.Unsign>(fastifyCookieNamed.unsign)
@@ -246,5 +245,5 @@ appWithHook.register(cookie, { hook: 'preValidation' })
 expectError(appWithHook.register(cookie, { hook: true }))
 expectError(appWithHook.register(cookie, { hook: 'false' }))
 
-expectType<(cookieHeader: string, opts?: fastifyCookieStar.ParseOptions) => { [key: string]: string }>(fastifyCookieDefault.parse)
-expectType<(name: string, value: string, opts?: fastifyCookieStar.SerializeOptions) => string>(fastifyCookieDefault.serialize)
+expectType<(cookieHeader: string, opts?: fastifyCookieStar.ParseOptions) => { [key: string]: string }>(cookie.parse)
+expectType<(name: string, value: string, opts?: fastifyCookieStar.SerializeOptions) => string>(cookie.serialize)


### PR DESCRIPTION
Resolves linting errors. See https://github.com/fastify/fastify-cookie/actions/runs/12611531804/job/35147292328

Also fixed duplicate imports in tests that the linter highlighted.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
