### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/fastify/fastify-cookie.git"
+    "url": "git+https://github.com/fastify/fastify-cookie.git"
   },
   "keywords": [
     "fastify",


### PR DESCRIPTION
## Summary
- replace the SSH-only repository URL with a public HTTPS Git URL
- keep npm repository metadata usable without GitHub SSH credentials

## Verification
- unit tests: 52 passed with 100% statement, branch, function, and line coverage
- TSTyche: 1 target and 46 assertions passed
- ESLint
- `pnpm pack --dry-run --json`
- direct package metadata assertion
- `git diff --check`