### PR TITLE
fix: register onSend writer even when hook is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,8 +146,10 @@ function plugin (fastify, options, next) {
 
   if (hook) {
     fastify.addHook(hook, onReqHandlerWrapper(fastify, hook))
-    fastify.addHook('onSend', fastifyCookieOnSendHandler)
   }
+  // The onSend writer is independent of the parsing hook: `hook: false` only
+  // disables cookie autoparsing, not the ability to set cookies on the reply.
+  fastify.addHook('onSend', fastifyCookieOnSendHandler)
 
   next()
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -929,6 +929,25 @@ test('dont add auto cookie parsing to onRequest-hook if hook-option is set to fa
   t.assert.strictEqual(res.statusCode, 200)
 })
 
+test('setCookie writes Set-Cookie even when hook-option is set to false', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.register(plugin, { hook: false })
+
+  fastify.get('/', (req, reply) => {
+    reply.setCookie('foo', 'bar', { path: '/' }).send({ hello: 'world' })
+  })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.ok(res.headers['set-cookie'], 'Set-Cookie should be written even with hook:false')
+})
+
 test('result in an error if hook-option is set to an invalid value', async (t) => {
   t.plan(1)
 


### PR DESCRIPTION
Previously the onSend handler that flushes queued cookies to the Set-Cookie header was gated by the same `if (hook)` block as the parsing hook, so registering the plugin with `hook: false` made reply.setCookie() a silent no-op. The docs scope `hook` to cookie parsing only, so the writer should be registered unconditionally. It already early-returns when no cookies were queued, so this is a no-op unless setCookie is used.

Adds a regression test.

Issue Link:https://github.com/fastify/fastify-cookie/issues/359 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
