### PR TITLE
fix: support cookie v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ upon this plugin's actions.
 It is also possible to [import the low-level cookie parsing and serialization functions](#importing-serialize-and-parse).
 
 ## Install
+
 ```sh
 npm i @fastify/cookie
 ```
 
 ### Compatibility
+
 | Plugin version | Fastify version |
 | ---------------|-----------------|
 | `>=10.x`       | `^5.x`          |
@@ -162,14 +164,13 @@ attribute. When truthy, the `Partitioned` attribute is set, otherwise it is not.
 
 More information about this can be found in [the proposal](https://github.com/privacycg/CHIPS).
 
-
 ##### priority
 
 Specifies the `string` to be the value for the [`Priority` `Set-Cookie` attribute](https://datatracker.ietf.org/doc/html/draft-west-cookie-priority-00#section-4.1).
 
-  - `'low'` will set the `Priority` attribute to `Low`.
-  - `'medium'` will set the `Priority` attribute to `Medium`, the default priority when not set.
-  - `'high'` will set the `Priority` attribute to `High`.
+- `'low'` will set the `Priority` attribute to `Low`.
+- `'medium'` will set the `Priority` attribute to `Medium`, the default priority when not set.
+- `'high'` will set the `Priority` attribute to `High`.
 
 More information about the different priority levels can be found in
 [the specification](https://datatracker.ietf.org/doc/html/draft-west-cookie-priority-00#section-4.1).
@@ -185,11 +186,11 @@ is considered the ["default path"](https://datatracker.ietf.org/doc/html/rfc6265
 
 Specifies the `boolean` or `string` to be the value for the [`SameSite` `Set-Cookie` attribute](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7).
 
-  - `true` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
-  - `false` will not set the `SameSite` attribute.
-  - `'lax'` will set the `SameSite` attribute to `Lax` for lax same site enforcement.
-  - `'none'` will set the `SameSite` attribute to `None` for an explicit cross-site cookie.
-  - `'strict'` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
+- `true` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
+- `false` will not set the `SameSite` attribute.
+- `'lax'` will set the `SameSite` attribute to `Lax` for lax same site enforcement.
+- `'none'` will set the `SameSite` attribute to `None` for an explicit cross-site cookie.
+- `'strict'` will set the `SameSite` attribute to `Strict` for strict same site enforcement.
 
 More information about the different enforcement levels can be found in
 [the specification](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-09#section-5.4.7).
@@ -214,7 +215,7 @@ as an object named `cookies`. Thus, if a request contains the header
 `Cookie: foo=foo` then, within your handler, `req.cookies.foo` would equal
 `'foo'`.
 
-You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cookieparsestr-options) by setting an object named `parseOptions` in the plugin config object.
+You can pass options to the [cookie parse](https://github.com/jshttp/cookie#cookieparsecookiestr-options) by setting an object named `parseOptions` in the plugin config object.
 
 ### Sending
 
@@ -223,11 +224,11 @@ via the Fastify `decorateReply` API. Thus, in a request handler,
 `reply.setCookie('foo', 'foo', {path: '/'})` will set a cookie named `foo`
 with a value of `'foo'` on the cookie path `/`.
 
-+ `name`: a string name for the cookie to be set
-+ `value`: a string value for the cookie
-+ `options`: an options object as described in the [cookie serialize][cs] documentation
-+ `options.signed`: the cookie should be signed
-+ `options.secure`: if set to `true` it will set the Secure-flag. If it is set to `"auto"` Secure-flag is set when the connection is using tls.
+- `name`: a string name for the cookie to be set
+- `value`: a string value for the cookie
+- `options`: an options object as described in the [cookie serialize][cs] documentation
+- `options.signed`: the cookie should be signed
+- `options.secure`: if set to `true` it will set the Secure-flag. If it is set to `"auto"` Secure-flag is set when the connection is using tls.
 
 #### Securing the cookie
 
@@ -245,8 +246,8 @@ via the Fastify `decorateReply` API. Thus, in a request handler,
 `reply.clearCookie('foo', {path: '/'})` will clear a cookie named `foo`
 on the cookie path `/`.
 
-+ `name`: a string name for the cookie to be cleared
-+ `options`: an options object as described in the [cookie serialize][cs]
+- `name`: a string name for the cookie to be cleared
+- `options`: an options object as described in the [cookie serialize][cs]
 documentation. It is optional to pass an `options` object
 
 ### Manual cookie parsing
@@ -255,14 +256,16 @@ The method `parseCookie(cookieHeader)` is added to the `fastify` instance
 via the Fastify `decorate` API. Thus, `fastify.parseCookie('sessionId=aYb4uTIhdBXC')`
 will parse the raw cookie header and return an object `{ "sessionId": "aYb4uTIhdBXC" }`.
 
-[cs]: https://www.npmjs.com/package/cookie#options-1
+[cs]: https://github.com/jshttp/cookie#cookiestringifysetcookiesetcookieobj-options
 
 <a id="rotating-secret"></a>
+
 ### Rotating signing secret
 
 Key rotation is when an encryption key is retired and replaced by generating a new cryptographic key. To implement rotation, supply an `Array` of keys to `secret` option.
 
 **Example:**
+
 ```js
 fastify.register(require('@fastify/cookie'), {
   secret: [key1, key2]
@@ -272,11 +275,13 @@ fastify.register(require('@fastify/cookie'), {
 The plugin will **always** use the first key (`key1`) to sign cookies. When parsing incoming cookies, it will iterate over the supplied array to see if any of the available keys are able to decode the given signed cookie. This ensures that any old signed cookies are still valid.
 
 Note:
+
 - Key rotation is **only** achieved by redeploying the server again with the new `secret` array.
 - Iterating through all secrets is an expensive process, so the rotation list should contain as few keys as possible. Ideally, only the current key and the most recently retired key.
 - Although previously signed cookies are valid even after rotation, cookies should be updated with the new key as soon as possible. See the following example for how to accomplish this.
 
 **Example:**
+
 ```js
 fastify.get('/', (req, reply) => {
   const result = reply.unsignCookie(req.cookies.myCookie)
@@ -293,11 +298,13 @@ fastify.get('/', (req, reply) => {
 ```
 
 <a id="custom-cookie-signer"></a>
+
 ### Custom cookie signer
 
 The `secret` option optionally accepts an object with `sign` and `unsign` functions. This allows for implementing a custom cookie signing mechanism. See the following example:
 
 **Example:**
+
 ```js
 fastify.register(require('@fastify/cookie'), {
   secret: {
@@ -381,7 +388,6 @@ const { fastifyCookie } = require('@fastify/cookie');
 const signedValue = fastifyCookie.sign('test', 'secret');
 const unsignedvalue = fastifyCookie.unsign(signedValue, 'secret');
 ```
-
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,9 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { parseCookie: cookieParse, stringifySetCookie } = require('cookie')
+const { parseCookie: parse, stringifySetCookie } = require('cookie')
 
 const { Signer, sign, unsign } = require('./signer')
-
-function parse (str, options) {
-  return cookieParse(str, options)
-}
 
 function serialize (name, value, options) {
   return stringifySetCookie(Object.assign({ name, value }, options))

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const cookie = require('cookie')
+const { parseCookie: cookieParse, stringifySetCookie } = require('cookie')
 
 const { Signer, sign, unsign } = require('./signer')
+
+function parse (str, options) {
+  return cookieParse(str, options)
+}
+
+function serialize (name, value, options) {
+  return stringifySetCookie(Object.assign({ name, value }, options))
+}
 
 const kReplySetCookies = Symbol('fastify.reply.setCookies')
 const kReplySetCookiesHookRan = Symbol('fastify.reply.setCookiesHookRan')
@@ -29,7 +37,11 @@ function fastifyCookieSetCookie (reply, name, value, options) {
     }
   }
 
-  reply[kReplySetCookies].set(`${name};${opts.domain};${opts.path || '/'}`, { name, value, opts })
+  reply[kReplySetCookies].set(`${name};${opts.domain};${opts.path || '/'}`, {
+    name,
+    value,
+    opts
+  })
 
   if (reply[kReplySetCookiesHookRan]) {
     setCookies(reply)
@@ -77,7 +89,7 @@ function setCookies (reply) {
     if (reply[kReplySetCookies].size === 1) {
       // Fast path for single cookie
       const c = reply[kReplySetCookies].values().next().value
-      reply.header('Set-Cookie', cookie.serialize(c.name, c.value, c.opts))
+      reply.header('Set-Cookie', serialize(c.name, c.value, c.opts))
       reply[kReplySetCookies].clear()
       return
     }
@@ -90,7 +102,7 @@ function setCookies (reply) {
   }
 
   for (const c of reply[kReplySetCookies].values()) {
-    cookieValue.push(cookie.serialize(c.name, c.value, c.opts))
+    cookieValue.push(serialize(c.name, c.value, c.opts))
   }
 
   reply.removeHeader('Set-Cookie')
@@ -117,12 +129,20 @@ function plugin (fastify, options, next) {
   const secret = options.secret
   const hook = getHook(options.hook)
   if (hook === undefined) {
-    return next(new Error('@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, \'onRequest\' , \'preParsing\' , \'preValidation\' or \'preHandler\''))
+    return next(
+      new Error(
+        "@fastify/cookie: Invalid value provided for the hook-option. You can set the hook-option only to false, 'onRequest' , 'preParsing' , 'preValidation' or 'preHandler'"
+      )
+    )
   }
-  const isSigner = !secret || (typeof secret.sign === 'function' && typeof secret.unsign === 'function')
-  const signer = isSigner ? secret : new Signer(secret, options.algorithm || 'sha256')
+  const isSigner =
+    !secret ||
+    (typeof secret.sign === 'function' && typeof secret.unsign === 'function')
+  const signer = isSigner
+    ? secret
+    : new Signer(secret, options.algorithm || 'sha256')
 
-  fastify.decorate('serializeCookie', cookie.serialize)
+  fastify.decorate('serializeCookie', serialize)
   fastify.decorate('parseCookie', parseCookie)
 
   if (secret !== undefined) {
@@ -153,7 +173,7 @@ function plugin (fastify, options, next) {
 
   // ***************************
   function parseCookie (cookieHeader) {
-    return cookie.parse(cookieHeader, options.parseOptions)
+    return parse(cookieHeader, options.parseOptions)
   }
 
   function signCookie (value) {
@@ -206,8 +226,8 @@ module.exports = fastifyCookie
 module.exports.default = fastifyCookie // supersedes fastifyCookie.default = fastifyCookie
 module.exports.fastifyCookie = fastifyCookie // supersedes fastifyCookie.fastifyCookie = fastifyCookie
 
-module.exports.serialize = cookie.serialize
-module.exports.parse = cookie.parse
+module.exports.serialize = serialize
+module.exports.parse = parse
 
 module.exports.signerFactory = Signer
 module.exports.Signer = Signer

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "tstyche": "^7.0.0"
   },
   "dependencies": {
-    "cookie": "^1.0.0",
+    "cookie": "^2.0.0",
     "fastify-plugin": "^6.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Proposal:

- Updates @fastify/cookie to work with `cookie v2.x`(v2.0.0: https://github.com/jshttp/cookie/releases/tag/v2.0.0). `cookie` v2 is a breaking release: it drops the `parse(str, opts)` and `serialize(name, value, opts)` exports entirely, replacing them with `parseCookie(str, opts)` and `stringifySetCookie({ name, value, ...opts }, encodeOpts)`.
Since `index.js` still called `cookie.parse(...)` / `cookie.serialize(...)`, every call became `undefined is not a function`, causing **every** route that touches cookies (setting, clearing, or parsing) to respond with a here: 500, see test errors here: https://github.com/fastify/fastify-cookie/actions/runs/28953073061/job/85904705783?pr=356#step:5:763 . 
- This PR should resolved this PR: https://github.com/fastify/fastify-cookie/pull/356

#### Change
- Import `parseCookie` / `stringifySetCookie` from `cookie v2.x` and wrap them in local `parse(str, opts)` / `serialize(name, value, opts)` helpers that preserve the old 3-argument call shape.
- Route all internal usages (`setCookie`, `clearCookie`, request cookie parsing, the `serializeCookie`/`parseCookie` decorators, and the `module.exports.serialize`/`.parse` aliases) through these wrappers, so the plugin's public API is unchanged.
- Bump `cookie` to `^2.0.0` in `package.json`.
- Fix two README links that referenced `cookie` v1's old anchor names.

